### PR TITLE
fix: 設定リセット時にVRMファイルを削除してデフォルトに戻す

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,10 @@ function App() {
             const url = createBlobURL(file);
             setVrmUrl(url);
             console.log('[App] VRM reloaded:', file.name);
+          } else {
+            // No custom VRM, load default
+            setVrmUrl(DEFAULT_VRM_URL);
+            console.log('[App] No custom VRM, using default');
           }
         }).catch((err) => {
           console.error('Failed to reload VRM file:', err);


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

設定のリセット機能を改善し、以下の修正を行いました：

- **IndexedDBからのVRMファイル削除**: リセット時にカスタムVRMファイルをIndexedDBから完全に削除
- **メインウィンドウへの通知**: VRM削除後にメインウィンドウに通知し、デフォルトVRMを再読み込み
- **デフォルトVRMへのフォールバック**: カスタムVRMがない場合、自動的にデフォルトVRMを読み込む処理を追加
- **スピーカー・音量のリセット**: リセット時にスピーカーIDと音量もデフォルト値に戻す

## :camera: なぜやったのか（背景・目的）

設定リセットボタンを押しても、IndexedDBに保存されたVRMファイルが削除されず、リセット後に再びカスタムVRMが表示されてしまう問題がありました。

これにより、ユーザーが意図した「完全に初期状態に戻す」挙動が実現されていませんでした。本修正により、リセット時にVRMファイルを完全に削除し、デフォルトのVRMモデルが表示されるように改善しました。

## :bookmark: 関連URL

なし