### PR TITLE
feat: 音声合成を並列実行して発話遅延を低減

### DIFF
--- a/src/hooks/useSpeech.ts
+++ b/src/hooks/useSpeech.ts
@@ -11,15 +11,20 @@ interface UseSpeechOptions {
 }
 
 interface QueueItem {
+  id: number;
   text: string;
   emotion: Emotion;
+  status: 'pending' | 'synthesizing' | 'ready' | 'playing';
+  audioBuffer?: AudioBuffer;
+  promise?: Promise<AudioBuffer>;
 }
 
 export function useSpeech({ onStart, onEnd, speakerId, baseUrl, volumeScale }: UseSpeechOptions) {
   const audioContextRef = useRef<AudioContext | null>(null);
   const [isReady, setIsReady] = useState(false);
   const isSpeakingRef = useRef(false);
-  const queueRef = useRef<QueueItem[]>([]);
+  const queueRef = useRef<Map<number, QueueItem>>(new Map());
+  const nextIdRef = useRef(0);
   const processQueueRef = useRef<(() => Promise<void>) | undefined>(undefined);
   const currentGainNodeRef = useRef<GainNode | null>(null);
 
@@ -43,36 +48,71 @@ export function useSpeech({ onStart, onEnd, speakerId, baseUrl, volumeScale }: U
     initialize();
   }, []);
 
+  // 音声合成を並列実行（キューに入ったら即座に開始）
+  const synthesizeAudio = useCallback(async (item: QueueItem) => {
+    if (!audioContextRef.current) return;
+
+    try {
+      console.log(`[useSpeech] Synthesizing item #${item.id}: "${item.text}"`);
+      const wavBuffer = await speak(item.text, speakerId, baseUrl);
+      const audioBuffer = await audioContextRef.current.decodeAudioData(wavBuffer);
+
+      // 音声合成完了、アイテムを更新
+      item.audioBuffer = audioBuffer;
+      item.status = 'ready';
+      console.log(`[useSpeech] Item #${item.id} synthesis complete`);
+
+      // 発話処理をトリガー
+      processQueueRef.current?.();
+    } catch (error) {
+      console.error(`[useSpeech] Synthesis failed for item #${item.id}:`, error);
+      // 失敗したアイテムは削除
+      queueRef.current.delete(item.id);
+      processQueueRef.current?.();
+    }
+  }, [speakerId, baseUrl]);
+
+  // 音声合成完了したアイテムを順番に発話
   const processQueue = useCallback(async () => {
-    if (isSpeakingRef.current || queueRef.current.length === 0) {
+    if (isSpeakingRef.current) {
       return;
     }
 
-    // AudioContextが準備できていない場合はキューをクリアして終了
+    // AudioContextが準備できていない場合は終了
     if (!isReady || !audioContextRef.current) {
-      console.warn('AudioContext not ready, discarding queued text');
-      queueRef.current = [];
+      console.warn('AudioContext not ready');
       return;
     }
-
-    const item = queueRef.current.shift();
-    if (!item) return;
 
     const ctx = audioContextRef.current;
 
-    // suspended状態なら無視して次へ
+    // suspended状態なら無視
     if (ctx.state === 'suspended') {
-      console.warn('AudioContext suspended, skipping:', item.text);
-      processQueueRef.current?.();
+      console.warn('AudioContext suspended, waiting');
+      return;
+    }
+
+    // 次に発話すべきアイテムを探す（ID順）
+    let nextItem: QueueItem | undefined;
+    for (const [id, item] of queueRef.current) {
+      if (item.status === 'ready') {
+        // まだ再生していない最も小さいIDのアイテムを再生
+        if (!nextItem || id < nextItem.id) {
+          nextItem = item;
+        }
+      }
+    }
+
+    if (!nextItem) {
+      // 準備完了アイテムがない場合は何もしない
       return;
     }
 
     try {
       isSpeakingRef.current = true;
+      nextItem.status = 'playing';
 
-      console.log(`[useSpeech] Synthesizing with Speaker ID: ${speakerId}`);
-      const wavBuffer = await speak(item.text, speakerId, baseUrl);
-      const audioBuffer = await ctx.decodeAudioData(wavBuffer);
+      console.log(`[useSpeech] Playing item #${nextItem.id}: "${nextItem.text}"`);
 
       const source = ctx.createBufferSource();
       const analyser = ctx.createAnalyser();
@@ -81,7 +121,7 @@ export function useSpeech({ onStart, onEnd, speakerId, baseUrl, volumeScale }: U
       analyser.fftSize = 256;
       gainNode.gain.value = volumeScale;
 
-      source.buffer = audioBuffer;
+      source.buffer = nextItem.audioBuffer!;
       // Audio graph: source -> analyser -> gain -> destination
       source.connect(analyser);
       analyser.connect(gainNode);
@@ -90,23 +130,28 @@ export function useSpeech({ onStart, onEnd, speakerId, baseUrl, volumeScale }: U
       // Store current gain node for real-time volume updates
       currentGainNodeRef.current = gainNode;
 
-      onStart(analyser, item.emotion);
+      onStart(analyser, nextItem.emotion);
 
       source.onended = () => {
+        console.log(`[useSpeech] Item #${nextItem.id} playback complete`);
+        // 完了したアイテムを削除
+        queueRef.current.delete(nextItem.id);
         isSpeakingRef.current = false;
         currentGainNodeRef.current = null;
         onEnd();
+        // 次のアイテムを処理
         processQueueRef.current?.();
       };
 
       source.start();
     } catch (error) {
-      console.error('Speech failed:', error);
+      console.error(`[useSpeech] Playback failed for item #${nextItem.id}:`, error);
+      queueRef.current.delete(nextItem.id);
       isSpeakingRef.current = false;
       onEnd();
       processQueueRef.current?.();
     }
-  }, [onStart, onEnd, isReady, speakerId, baseUrl, volumeScale]);
+  }, [onStart, onEnd, isReady, volumeScale]);
 
   useEffect(() => {
     processQueueRef.current = processQueue;
@@ -129,10 +174,23 @@ export function useSpeech({ onStart, onEnd, speakerId, baseUrl, volumeScale }: U
       return;
     }
 
-    console.log(`Queued: "${text}" with emotion "${emotion}" (queue size: ${queueRef.current.length})`);
-    queueRef.current.push({ text, emotion });
-    processQueueRef.current?.();
-  }, [isReady]);
+    const id = nextIdRef.current++;
+    const item: QueueItem = {
+      id,
+      text,
+      emotion,
+      status: 'pending',
+    };
+
+    console.log(`[useSpeech] Queued item #${id}: "${text}" with emotion "${emotion}"`);
+
+    // キューに追加
+    queueRef.current.set(id, item);
+
+    // 即座に音声合成を開始（並列実行）
+    item.status = 'synthesizing';
+    synthesizeAudio(item);
+  }, [isReady, synthesizeAudio]);
 
   return { speakText, isReady };
 }


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要)

音声合成処理の並列化を行い、連続するセリフの発話遅延を低減しました。

**Before（直列処理）:**
```
セリフ1追加 → 音声合成 → 発話 → 終了
              ↑ 待ち時間 ↑
セリフ2追加 ─────────────────→ 音声合成 → 発話 → 終了
```

**After（並列音声合成 + 順次発話）:**
```
セリフ1追加 → 音声合成(並列) ─┐
セリフ2追加 → 音声合成(並列) ─┼→ 発話(キュー順) → 終了
セリフ3追加 → 音声合成(並列) ─┘
```

**主な変更点:**
- `QueueItem`にIDと状態管理（`pending` → `synthesizing` → `ready` → `playing`）を追加
- 音声合成処理（`synthesizeAudio`）を分離し、キュー追加時に即座に並列実行
- 発話処理（`processQueue`）をID順（追加順）に厳密に実行するよう変更
- 後から追加されたセリフの音声合成が先に終わっても、発話順序が逆転しないことを保証

## :camera: なぜやったのか（背景・目的)

連続するセリフが発話される際、現在の処理では音声合成→発話→終了の直列処理となっており、次のセリフの音声合成が現在の発話終了まで待機される問題がありました。

音声合成は処理が重く時間がかかることがあるため、この待機時間が発話遅延として顕著に現れていました。

これを改善するため、セリフがキューに追加されたら直ちに音声合成を並列実行し、発話は追加順（ID順）に厳密に実行する構造に変更しました。

## :bookmark: 関連URL

なし