### PR TITLE
fix: merge-prコマンドでgit fetch --pruneを使用するように修正

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -57,11 +57,8 @@ gh pr merge <PR番号> --merge --delete-branch
 
 2. ローカルのGit情報を最新化する
 
-10秒待ってから下記コマンドを実行する
-（サーバー側の処理を待つ）
-
 ```bash
-git fetch
+git fetch --prune
 ```
 
 3. ベースブランチをCheckoutする


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

merge-prコマンドのGit更新処理において、不要なコメントを削除し、`git fetch` を `git fetch --prune` に変更しました。これにより、リモートで削除されたブランチ情報がローカルに残り続ける問題を防止できます。

## :camera: なぜやったのか（背景・目的）

PRのマージ後に、リモートブランチが削除された場合でも、ローカルにそのブランチの参照が残り続ける問題がありました。`--prune` オプションを使用することで、リモートで削除されたブランチの参照をローカルからも自動的に削除し、リポジトリを綺麗に保つことができます。

また、不要なコメント（10秒待機の指示）を削除し、コマンドを簡潔にしました。

## :bookmark: 関連URL

---

Co-Written-By: Claude Sonnet 4.5 <noreply@anthropic.com>