### PR TITLE
docs: merge-prコマンドのワークフローを簡潔に修正

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -51,6 +51,8 @@ gh pr view <PR番号> --json mergeable,mergeStateStatus
 
 1. PRをマージする
 
+※`--delete-branch`を指定していると自動的にマージ先のベースブランチがチェックアウトされる
+
 ```bash
 gh pr merge <PR番号> --merge --delete-branch
 ```
@@ -61,19 +63,13 @@ gh pr merge <PR番号> --merge --delete-branch
 git fetch --prune
 ```
 
-3. ベースブランチをCheckoutする
-
-```bash
-git checkout <ベースブランチ>
-```
-
-4. ベースブランチの状態をリモートに合わせる
+3. ベースブランチの状態をリモートに合わせる
 
 ```bash
 git merge --ff-only
 ```
 
-5. スタッシュした変更があればどうするか確認する
+4. スタッシュした変更があればどうするか確認する
 
 `AskUserQuestion`ツールを使用してスタッシュ内容をどうするかどうかユーザーに問い合わせてください
     - 退避した変更をapply（戻すが削除しない）


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

merge-prコマンドのドキュメントにおいて、`--delete-branch`オプション使用時に自動的にベースブランチがチェックアウトされる挙動についての注記を追加しました。また、不要な手順（ベースブランチのチェックアウト）を削除し、ワークフローをより明確にしました。

## :camera: なぜやったのか（背景・目的）

`gh pr merge --delete-branch`コマンドを使用すると、マージ後に自動的にベースブランチがチェックアウトされる仕様についての記述が不足しており、ユーザーが余計な操作を行う可能性がありました。ドキュメントを簡潔にすることで、コマンドの挙動を正しく理解できるようにしました。

## :bookmark: 関連URL

なし

---

Co-Written-By: Claude Sonnet 4.5 <noreply@anthropic.com>