### PR TITLE
revert: merge-prコマンドのドキュメントから不要な注記を削除

### DIFF
--- a/.claude/commands/merge-pr.md
+++ b/.claude/commands/merge-pr.md
@@ -51,8 +51,6 @@ gh pr view <PR番号> --json mergeable,mergeStateStatus
 
 1. PRをマージする
 
-※`--delete-branch`を指定していると自動的にマージ先のベースブランチがチェックアウトされる
-
 ```bash
 gh pr merge <PR番号> --merge --delete-branch
 ```
@@ -63,13 +61,7 @@ gh pr merge <PR番号> --merge --delete-branch
 git fetch --prune
 ```
 
-3. ベースブランチの状態をリモートに合わせる
-
-```bash
-git merge --ff-only
-```
-
-4. スタッシュした変更があればどうするか確認する
+3. スタッシュした変更があればどうするか確認する
 
 `AskUserQuestion`ツールを使用してスタッシュ内容をどうするかどうかユーザーに問い合わせてください
     - 退避した変更をapply（戻すが削除しない）


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

merge-prコマンドのドキュメントにおいて、前回追加した`--delete-branch`オプションの自動チェックアウト挙動についての注記と、不要な手順（ベースブランチの状態をリモートに合わせる）を削除し、ワークフローを元に戻しました。

## :camera: なぜやったのか（背景・目的）

前回の変更で追加した`--delete-branch`オプションの自動チェックアウト挙動についての注記が、実際の挙動と異なっていたため削除しました。また、実行時に不要であることが判明した手順を削除し、ドキュメントを正確な状態に戻しました。

## :bookmark: 関連URL

なし

---

Co-Written-By: Claude Sonnet 4.5 <noreply@anthropic.com>