### PR TITLE
feat: ウィンドウ位置の記憶機能を実装

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -185,6 +185,14 @@ const createWindow = () => {
     mainWindow.loadFile(path.join(__dirname, "../dist/index.html"));
   }
 
+  // Restore saved position after window is ready (overrides OS auto-correction)
+  mainWindow.once("ready-to-show", () => {
+    if (savedPosition && mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.setPosition(savedPosition.x, savedPosition.y);
+      console.log(`[Window] Position restored to (${savedPosition.x}, ${savedPosition.y})`);
+    }
+  });
+
   mainWindow.on("closed", () => {
     mainWindow = null;
   });


### PR DESCRIPTION
## 概要
ウィンドウ位置を記憶し、アプリ再起動時に復元する機能を実装しました。

## :memo: 変更内容

- ウィンドウ作成時に前回の位置を復元する機能を追加
- ウィンドウ移動時に位置を自動保存（Electron Store使用）
- `reset-all-settings`実行時に位置情報もクリア
- 画面外のウィンドウ位置も維持するバグ修正（ready-to-show イベントで再設定）

## :sparkles: 主な変更

### electron/main.ts
- ウィンドウ位置の永続化・復元ロジックを追加
- 移動イベント監視で自動保存
- 位置情報のクリア機能を追加

## :link: 関連URL
なし

## :check: テスト計画
- [x] アプリ終了時にウィンドウ位置が保存されること
- [x] アプリ起動時に前回の位置で復元されること
- [x] デスクトップ外の位置でも正しく維持されること
- [x] 設定リセット時に位置情報もクリアされること

---

Co-Written-By: Claude Sonnet 4.5 <noreply@anthropic.com>