### PR TITLE
:bug: happy表情適用時に瞬きをスキップするように修正

### DIFF
--- a/src/hooks/useBlink.ts
+++ b/src/hooks/useBlink.ts
@@ -31,21 +31,13 @@ export function useBlink(vrm: VRM | null, options: UseBlinkOptions = {}) {
     return Math.random() * (maxInterval - minInterval) + minInterval;
   }, [minInterval, maxInterval]);
 
-  // 瞬きをスキップすべきか判定
-  const shouldSkipBlink = useCallback((): boolean => {
-    if (!vrm?.expressionManager) return false;
-
-    // happy表情をチェック（笑顔の時は瞬きをスキップ）
-    const happyValue = vrm.expressionManager.getValue("happy");
-    return (happyValue ?? 0) > HAPPY_EXPRESSION_THRESHOLD;
-  }, [vrm]);
-
   // なめらかなまばたきアニメーション
   const performBlink = useCallback(() => {
     if (!vrm?.expressionManager || !enabled) return;
 
-    // happy表情や目を閉じる表情が適用されている場合はスキップ
-    if (shouldSkipBlink()) {
+    // happy表情をチェック（笑顔の時は瞬きをスキップ）
+    const happyValue = vrm.expressionManager.getValue("happy");
+    if ((happyValue ?? 0) > HAPPY_EXPRESSION_THRESHOLD) {
       return;
     }
 


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

happy表情の適用中に瞬きアニメーションをスキップする機能を追加しました。

- `shouldSkipBlink`関数を追加し、happy表情の値が0.1より大きい場合に瞬きをスキップ
- 閾値を0.1に設定し、Lerpによる徐々に変化する表情値を適切に判定
- happy表情からneutralに戻った後、値が0.1以下になったら瞬きが再開されます

## :camera: なぜやったのか（背景・目的）

happy表情は目を閉じる動作を持っていますが、従来の実装では瞬きアニメーションも同時に実行されていたため、以下の問題が発生していました：

- 瞬きとhappy表情の二重の動作で、まぶたが下がりすぎてモデルにめり込む
- 一度happy表情が適用されると、その後ずっと瞬きをしなくなる（Lerpによる微小な値が判定に影響）

この修正により、happy表情適用中は瞬きをスキップし、目が閉じている時は自然な動作になるようにしました。

## :bookmark: 関連URL

- #43

---

Co-Written-By: Claude Sonnet 4.5 <noreply@anthropic.com>