### PR TITLE
:up: TypeScriptのtargetをES2024に統合

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2023",
+    "target": "ES2024",
     "useDefineForClassFields": true,
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "types": ["vite/client"],
     "skipLibCheck": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
-    "lib": ["ES2023"],
+    "target": "ES2024",
+    "lib": ["ES2024"],
     "module": "ESNext",
     "types": ["node"],
     "skipLibCheck": true,


### PR DESCRIPTION
## 概要

tsconfigのtargetをES2023からES2024にアップグレードしました。

## 変更内容

- **tsconfig.app.json**: `target` と `lib` をES2023からES2024に変更
- **tsconfig.node.json**: `target` と `lib` をES2023からES2024に変更

## 目的

- 最新のECMAScript 2024の機能を利用可能にするため
- TypeScript設定の一貫性を維持するため

## テスト計画

- [x] `npm run build` が正常に完了すること
- [x] `npm run lint` で型チェックが通ること

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)