### PR TITLE
GitHubワークフローのブランチ設定を更新

### DIFF
--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -2,10 +2,9 @@ name: Run build
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, production]
   pull_request:
-    branches: [main, develop]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_lint.yml
+++ b/.github/workflows/run_lint.yml
@@ -2,10 +2,9 @@ name: Run lint
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, production]
   pull_request:
-    branches: [main, develop]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -2,10 +2,9 @@ name: Run test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, production]
   pull_request:
-    branches: [main, develop]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 概要
GitHub Actionsのワークフロー設定を更新し、ブランチ運用を見直します。

## 変更内容
- **ブランチ名**: `develop` → `production` に変更
- **PRトリガー**: `closed` イベントを削除（PRが閉じられたときの実行を除外）

## 背景
`develop` ブランチから `production` ブランチへの運用変更に対応するため。

---

Written-By: Claude Sonnet 4.5