### PR TITLE
システムトレイ機能を追加して常駐アプリ化

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,15 @@
       "dist-electron/**/*",
       "public/**/*"
     ],
+    "extraResources": [
+      {
+        "from": "resources/icons/",
+        "to": "icons/",
+        "filter": [
+          "tray*"
+        ]
+      }
+    ],
     "mac": {
       "icon": "resources/icons/icon.icns",
       "target": "dmg",


### PR DESCRIPTION
## Summary
- ウィンドウを閉じてもバックグラウンドで動作を継続するようシステムトレイ機能を実装
- macOSではDockアイコンを非表示にし、トレイアイコンのみで動作
- トレイアイコンから「設定を開く」「終了」のメニューを提供

## 主な変更内容
- `createTray()` 関数を追加してシステムトレイアイコンとコンテキストメニューを実装
- `getTrayIconPath()` でプラットフォームごとに適切なアイコンパスを取得
- macOS専用のテンプレートアイコン対応（ダーク/ライトモード自動切り替え）
- `window-all-closed` イベントでアプリを終了しないよう変更
- トレイアイコン用リソースを `package.json` の `extraResources` に追加

## Test plan
- [ ] macOSで起動してDockアイコンが非表示になることを確認
- [ ] トレイアイコンが表示され、クリックでメニューが開くことを確認
- [ ] 「設定を開く」メニューで設定ウィンドウが開くことを確認
- [ ] 「終了」メニューでアプリが正常に終了することを確認
- [ ] メインウィンドウを閉じてもアプリがバックグラウンドで動作し続けることを確認
- [ ] Windowsでもトレイアイコンが正常に動作することを確認

---

Written-By: Claude Sonnet 4.5