### PR TITLE
キャラクター位置リセット機能を追加

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -439,6 +439,17 @@ ipcMain.handle("reset-character-size", () => {
   return defaultSize;
 });
 
+// Reset character position to default (center-bottom)
+ipcMain.handle("reset-character-position", () => {
+  store.delete("characterPosition");
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("character-position-reset");
+  }
+
+  return true;
+});
+
 // Character position persistence
 ipcMain.handle("get-character-position", () => {
   return store.get("characterPosition") as { x: number; y: number } | undefined;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -82,6 +82,18 @@ contextBridge.exposeInMainWorld("electron", {
   setCharacterPosition: (x: number, y: number): void => {
     ipcRenderer.send("set-character-position", x, y);
   },
+  resetCharacterPosition: (): Promise<boolean> => {
+    return ipcRenderer.invoke("reset-character-position");
+  },
+  onCharacterPositionReset: (callback: () => void) => {
+    const listener = () => {
+      callback();
+    };
+    ipcRenderer.on("character-position-reset", listener);
+    return () => {
+      ipcRenderer.removeListener("character-position-reset", listener);
+    };
+  },
   onCharacterSizeChanged: (callback: (size: number) => void) => {
     const listener = (_event: unknown, size: number) => {
       callback(size);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,26 @@ function App() {
     };
   }, []);
 
+  // Listen for character position reset from settings window
+  useEffect(() => {
+    if (!window.electron?.onCharacterPositionReset || !window.electron?.getScreenSize) return;
+
+    const cleanup = window.electron.onCharacterPositionReset(async () => {
+      const screenSize = await window.electron!.getScreenSize();
+      const size = containerSizeRef.current;
+      const center = {
+        x: Math.round(screenSize.width / 2),
+        y: Math.round(screenSize.height - size / 2),
+      };
+      setContainerCenter(center);
+      containerCenterRef.current = center;
+    });
+
+    return () => {
+      cleanup?.();
+    };
+  }, []);
+
   // Load VRM from IndexedDB on mount
   useEffect(() => {
     loadVRMFile()

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -499,12 +499,22 @@ export default function SettingsApp() {
         {/* Reset Section */}
         <div>
           <h2 className="m-0 mb-4 text-lg font-semibold text-gray-800">リセット</h2>
-          <button
-            className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer transition-all duration-200 border-0 bg-danger text-white w-fit hover:bg-danger-dark"
-            onClick={handleReset}
-          >
-            全ての設定をリセット
-          </button>
+          <div className="flex flex-col gap-3">
+            <button
+              className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer transition-all duration-200 border border-solid border-gray-300 bg-white text-gray-700 w-fit hover:bg-gray-100"
+              onClick={() => {
+                window.electron?.resetCharacterPosition?.();
+              }}
+            >
+              キャラクター位置をリセット
+            </button>
+            <button
+              className="px-4 py-2 rounded-md text-sm font-medium cursor-pointer transition-all duration-200 border-0 bg-danger text-white w-fit hover:bg-danger-dark"
+              onClick={handleReset}
+            >
+              全ての設定をリセット
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -20,6 +20,8 @@ declare global {
       resetCharacterSize: () => Promise<number>;
       getCharacterPosition: () => Promise<{ x: number; y: number } | undefined>;
       setCharacterPosition: (x: number, y: number) => void;
+      resetCharacterPosition: () => Promise<boolean>;
+      onCharacterPositionReset: (callback: () => void) => () => void;
       onCharacterSizeChanged: (callback: (size: number) => void) => () => void;
       getScreenSize: () => Promise<{ width: number; height: number }>;
       resetAllSettings: () => Promise<boolean>;


### PR DESCRIPTION
## Summary

設定画面からキャラクター位置を初期値（画面中央下）にリセットできる機能を追加しました。

- Main Process: `reset-character-position` IPCハンドラを追加
- Preload: `resetCharacterPosition` API、`onCharacterPositionReset` リスナーを公開  
- Renderer: リセット時にコンテナ位置を画面中央下に戻す処理を実装
- Settings: 「キャラクター位置をリセット」ボタンを追加

## Test plan

- [ ] 設定画面を開く
- [ ] キャラクターを任意の位置にドラッグ移動する
- [ ] 設定画面の「キャラクター位置をリセット」ボタンをクリックする
- [ ] キャラクターが画面中央下に移動することを確認する
- [ ] アプリを再起動しても位置がリセットされたままであることを確認する

---

Written-By: Claude Sonnet 4.5