### PR TITLE
:bug: macOSで起動時のDockアイコン非表示処理を修正

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -273,6 +273,15 @@ const createWindow = () => {
   mainWindow.once("ready-to-show", () => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.setBounds({ x: workX, y: workY, width: workW, height: workH });
+
+      // macOS: ウィンドウが表示された後にDockを非表示にする
+      // ※起動時にapp.dock.hide()を呼ぶとフルスクリーンSpaceで起動してしまうため
+      if (process.platform === "darwin" && app.dock) {
+        setTimeout(() => {
+          app.dock.hide();
+          console.log("[Main] Dock icon hidden after window shown");
+        }, 500);
+      }
     }
   });
 
@@ -786,11 +795,6 @@ ipcMain.on("set-ignore-mouse-events", (_event, ignore: boolean) => {
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 app.whenReady().then(async () => {
-  // macOS: Dockアイコンを非表示にする（常駐アプリのため）
-  if (process.platform === "darwin" && app.dock) {
-    app.dock.hide();
-  }
-
   createTray();
   await startVoicevoxEngine();
   createWindow();


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

macOSにおいて、Dockアイコン非表示処理（`app.dock.hide()`）の呼び出しタイミングを変更しました。

- **変更前**: アプリ起動時（`app.whenReady()`）に即座に`app.dock.hide()`を呼んでいた
- **変更後**: ウィンドウが表示された後（`ready-to-show`イベント）に500ms遅延させてから`app.dock.hide()`を呼ぶように変更

## :camera: なぜやったのか（背景・目的）

アプリ起動時に`app.dock.hide()`を即座に呼ぶと、macOSでフルスクリーンSpaceで起動してしまう問題が発生していました。

これを回避するため、ウィンドウが正しく表示されたことを確認した後にDockを非表示にすることで、通常のSpaceで起動するように修正しました。

## :bookmark: 関連URL

なし

---

Written-By: Claude Sonnet 4.5