### PR TITLE
:rocket: ビルド時に全てのアイコンファイルをコピー対象に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,10 +82,7 @@
     "extraResources": [
       {
         "from": "resources/icons/",
-        "to": "icons/",
-        "filter": [
-          "tray*"
-        ]
+        "to": "icons/"
       }
     ],
     "mac": {


### PR DESCRIPTION
## 概要

ビルド時のリソースコピー設定からフィルター条件を削除し、`resources/icons/` ディレクトリ内の全てのファイルをリソースに含めるように変更しました。

## 変更内容

- **package.json**: `extraResources` から `filter` 設定（`tray*`のみ対象）を削除
- これにより、アイコンディレクトリ内の全ファイルがビルド成果物に含まれるようになります

## 動機

特定のファイルのみをコピー対象とするフィルター設定を削除し、アイコンディレクトリ全体をリソースとして含めるように設定を簡素化しました。

## テスト計画

- [ ] ビルド後に全てのアイコンファイルがリソースに含まれていることを確認
- [ ] アプリケーションが正常に動作することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Written-By: Claude Sonnet 4.5