### PR TITLE
macOSアプリの署名・公証設定を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Import Apple API key
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+        run: |
+          mkdir -p ~/private_keys
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+
       - name: Build and package
         run: npm run package
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_PATH: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "productName": "CC Mascot",
     "icon": "resources/icons/icon.png",
     "publish": null,
+    "afterSign": "scripts/notarize.js",
     "directories": {
       "output": "release"
     },
@@ -89,7 +90,11 @@
     "mac": {
       "icon": "resources/icons/icon.icns",
       "target": "dmg",
-      "category": "public.app-category.entertainment"
+      "category": "public.app-category.entertainment",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist"
     },
     "win": {
       "icon": "resources/icons/icon.ico",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,28 @@
+import { notarize } from "@electron/notarize";
+
+export default async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;
+
+  if (electronPlatformName !== "darwin") {
+    return;
+  }
+
+  if (!process.env.CI) {
+    console.log("Skipping notarization - not in CI environment");
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = `${appOutDir}/${appName}.app`;
+
+  console.log(`Notarizing ${appPath}...`);
+
+  await notarize({
+    appPath,
+    appleApiKey: process.env.APPLE_API_KEY_PATH,
+    appleApiKeyId: process.env.APPLE_API_KEY_ID,
+    appleApiIssuer: process.env.APPLE_API_ISSUER,
+  });
+
+  console.log("Notarization complete");
+}


### PR DESCRIPTION
## Summary

macOSアプリの配布に必要な署名・公証（Notarization）設定を追加しました。

- GitHub Actionsワークフローに署名・公証の環境設定を追加
- Hardened RuntimeとEntitlementsファイルの設定
- 自動公証スクリプトの実装

## 主な変更内容

### GitHub Actionsワークフロー (.github/workflows/release.yml)

- Apple API鍵をbase64デコードしてインポート
- コード署名証明書の環境変数を設定
- ビルド時に公証処理を自動実行

### ビルド設定 (package.json)

- `hardenedRuntime: true` を有効化
- Entitlementsファイルを指定
- 公証処理の自動実行スクリプトを追加

### Entitlementsファイル (build/entitlements.mac.plist)

- JIT許可
- ネットワーク接続許可
- ファイルアクセス許可

### 公証スクリプト (scripts/notarize.js)

- CI環境でのみ実行
- Apple API鍵を使用した公証処理
- @electron/notarizeを使用

## Test plan

- [ ] GitHub Actionsでビルドが成功することを確認
- [ ] dmgファイルが正しく署名されていることを確認
- [ ] 公証処理が正常に完了することを確認
- [ ] macOSでアプリが正常に起動することを確認

---

Written-By: Claude Sonnet 4.5