### PR TITLE
Improve release workflow trigger and secrets management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  pull_request:
+  push:
     branches: [production]
-    types: [closed]
   workflow_dispatch:
 
 permissions:
@@ -59,16 +58,16 @@ jobs:
           APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
         run: |
           mkdir -p ~/private_keys
-          echo "$APPLE_API_KEY_BASE64" | base64 --decode > ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > ~/private_keys/AuthKey_${{ vars.APPLE_API_KEY_ID }}.p8
 
       - name: Build and package
         run: npm run package
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_API_KEY_PATH: ~/private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_PATH: ~/private_keys/AuthKey_${{ vars.APPLE_API_KEY_ID }}.p8
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Change release workflow trigger from `pull_request` (closed) to `push` for automatic releases when changes are pushed to production branch
- Migrate non-sensitive Apple API configuration from secrets to vars following GitHub's best practices

## Changes
- **Workflow trigger**: Changed from `pull_request` with `closed` type to `push` on production branch
  - This ensures releases are triggered automatically when changes are pushed to the production branch
  - More straightforward and reliable than relying on PR merge events
- **Secrets management**: Migrated non-sensitive Apple API configuration
  - `APPLE_API_KEY_ID`: secrets → vars (key identifier is not sensitive)
  - `APPLE_API_ISSUER`: secrets → vars (issuer ID is not sensitive)  
  - `APPLE_API_KEY_BASE64`: remains in secrets (contains actual private key data)

## Test plan
- [ ] Verify workflow triggers correctly on push to production branch
- [ ] Verify workflow can still be triggered manually via workflow_dispatch
- [ ] Confirm Apple API configuration variables are properly set in repository settings
- [ ] Test that the build and notarization process works with the new variable references

---

Written-By: Claude Sonnet 4.5