### PR TITLE
Fix Apple API key file path handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,20 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Apple API key
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+        run: |
+          mkdir -p ~/private_keys
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > ~/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8
+
       - name: Build and package
         run: npm run package
         env:
           CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY: ~/private_keys/AuthKey_${{ vars.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
 

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -19,7 +19,7 @@ export default async function notarizing(context) {
 
   await notarize({
     appPath,
-    appleApiKey: process.env.APPLE_API_KEY_PATH,
+    appleApiKey: process.env.APPLE_API_KEY,
     appleApiKeyId: process.env.APPLE_API_KEY_ID,
     appleApiIssuer: process.env.APPLE_API_ISSUER,
   });


### PR DESCRIPTION
## Summary
- notarize.jsの環境変数名を`APPLE_API_KEY_PATH`から`APPLE_API_KEY`に修正
- release.ymlでビルド前にAPIキーファイルを明示的に作成するステップを追加
- ファイルパスを環境変数経由で渡すように変更

## Test plan
- [ ] リリースワークフローが正常に動作することを確認
- [ ] macOSアプリの公証が成功することを確認

---

Written-By: Claude Sonnet 4.5