### PR TITLE
:bug: リリースアーティファクトのアップロード設定を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,6 @@ jobs:
           APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
 
-      - name: Remove debug files from artifacts
-        run: rm -f release/builder-debug.yml
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -97,7 +94,7 @@ jobs:
           path: |
             release/*.dmg
             release/*.zip
-            release/*.yml
+            release/latest*.yml
             release/*.blockmap
 
   build-windows:
@@ -121,9 +118,6 @@ jobs:
       - name: Build and package
         run: npm run package
 
-      - name: Remove debug files from artifacts
-        run: Remove-Item release/builder-debug.yml -ErrorAction SilentlyContinue
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -131,7 +125,7 @@ jobs:
           path: |
             release/*.exe
             release/*.zip
-            release/*.yml
+            release/latest*.yml
             release/*.blockmap
 
   create-release:


### PR DESCRIPTION
## :clipboard: 概要

リリースワークフローにおけるアーティファクトのアップロード設定を修正し、不要なステップを削除しました。

---

## :pencil2: 変更内容

- 不要なdebugファイル削除ステップを削除（macOS/Windowsの両ビルドから）
- アーティファクトアップロード時のymlファイル指定を `latest*.yml` に絞り込み

---

## :rocket: 主な変更点

### .github/workflows/release.yml

- `Remove debug files from artifacts` ステップを削除
  - macOSビルド: `rm -f release/builder-debug.yml` を削除
  - Windowsビルド: `Remove-Item release/builder-debug.yml -ErrorAction SilentlyContinue` を削除
- アーティファクトアップロードのパス指定を変更
  - `release/*.yml` → `release/latest*.yml` に変更

---

## :wrench: 技術詳細

- 不要なファイル削除ステップを削除することで、ワークフローをシンプルにしました
- `latest*.yml` のみをアップロード対象にすることで、必要なファイルのみを確実にアップロードするようにしました

---

## :link: 関連URL



---

## :checklist: チェックリスト

- [x] コードが意図した動作をすることを確認した
- [x] 不要なdebugファイル削除ステップを削除した
- [x] ymlファイルの指定を `latest*.yml` に絞り込んだ

---

Written-By: Claude Sonnet 4.5