### PR TITLE
Fix release workflow to checkout correct version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.version }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -105,6 +107,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.version }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- リリースワークフローでbump-versionジョブが作成したバージョンタグを正しくチェックアウトするように修正
- build-linuxとbuild-windowsジョブで`ref: ${{ needs.bump-version.outputs.version }}`を指定

## Background

現在のリリースワークフローでは、bump-versionジョブでバージョンタグを作成した後、build/packageジョブが実行される際にデフォルトブランチ（main）をチェックアウトしていました。これにより、バージョンアップ後の正しいソースコードでビルドされない可能性がありました。

## Changes

`.github/workflows/release.yml`のbuild-linuxとbuild-windowsジョブに以下を追加：

```yaml
- name: Checkout repository
  uses: actions/checkout@v4
  with:
    ref: ${{ needs.bump-version.outputs.version }}
```

## Test plan

- [ ] リリースワークフローが正常に動作することを確認
- [ ] ビルドジョブが正しいバージョンのソースコードを使用していることを確認

---

Written-By: Claude Sonnet 4.5