### PR TITLE
Add VRM model auto-fit positioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       version_bump:
-        description: 'バージョンのインクリメント方法を選択'
+        description: "バージョンのインクリメント方法を選択"
         required: true
         type: choice
         options:
           - major
           - minor
           - patch
-        default: 'patch'
+        default: "patch"
 
 permissions:
   contents: write

--- a/scripts/build-mic-monitor.mjs
+++ b/scripts/build-mic-monitor.mjs
@@ -91,7 +91,7 @@ function buildWin32() {
   try {
     console.log("[build-mic-monitor] Compiling C++ helper with MSVC...");
     // MSVC outputs .obj files to the current directory, not the source directory
-    const objFileName = source.split('/').pop().replace(".cpp", ".obj");
+    const objFileName = source.split("/").pop().replace(".cpp", ".obj");
     execSync(`cmd /c ""${vcvarsall}" x64 && cl /O2 /EHsc ${source} Ole32.lib /Fe:${output} && del ${objFileName}"`, {
       stdio: "inherit",
     });

--- a/src/hooks/useVRM.test.ts
+++ b/src/hooks/useVRM.test.ts
@@ -44,6 +44,17 @@ vi.mock("three", () => ({
   MathUtils: {
     lerp: (a: number, b: number, t: number) => a + (b - a) * t,
   },
+  Box3: vi.fn(function () {
+    return {
+      setFromObject: vi.fn(function () {
+        this.min = { x: -0.3, y: 0, z: -0.3 };
+        this.max = { x: 0.3, y: 1.6, z: 0.3 };
+        return this;
+      }),
+      min: { x: -0.3, y: 0, z: -0.3 },
+      max: { x: 0.3, y: 1.6, z: 0.3 },
+    };
+  }),
 }));
 
 describe("useVRM", () => {


### PR DESCRIPTION
## Summary

異なるサイズのVRMモデルでも自動的に適切な位置・スケールで表示されるようにする機能を追加しました。

- VRMモデルのバウンディングボックスを計算し、基準高さ（1.5m）に正規化
- 足の位置を一定に保つように自動調整
- モデルサイズが異なっても手動調整不要に
- VRMBounds インターフェースを追加（モデルの高さ、中心X座標、最小Y座標を追跡）
- VRMAvatar コンポーネントで計算されたスケール・位置変換を適用

## Test plan

- [x] デフォルトVRMモデルが正しく表示されることを確認
- [x] 異なるサイズのVRMモデルを読み込んでも適切にスケール・位置調整されることを確認
- [x] バウンディングボックス計算のユニットテストが通ることを確認

---

Written-By: Claude Opus 4.6