### PR TITLE
Fix mic state initialization to prevent mute state mismatch

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -945,6 +945,11 @@ ipcMain.handle("get-devtools-state", (_event, target: "main" | "settings") => {
   return settingsWindow?.webContents.isDevToolsOpened() ?? false;
 });
 
+// Get current mic active state (for initial state query from renderer)
+ipcMain.handle("get-mic-active", () => {
+  return micActive;
+});
+
 // Mic monitor settings
 ipcMain.handle("get-mute-on-mic-active", () => {
   const value = store.get("muteOnMicActive");
@@ -962,7 +967,10 @@ ipcMain.handle("set-mute-on-mic-active", (_event, value: boolean) => {
       mainWindow.webContents.send("mic-active-changed", false);
     }
   }
-  // Notify settings window of the change
+  // Notify main window and settings window of the change
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("mute-on-mic-active-changed", value);
+  }
   if (settingsWindow && !settingsWindow.isDestroyed()) {
     settingsWindow.webContents.send("mute-on-mic-active-changed", value);
   }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -138,6 +138,9 @@ contextBridge.exposeInMainWorld("electron", {
       ipcRenderer.removeListener("play-test-speech", listener);
     };
   },
+  getMicActive: (): Promise<boolean> => {
+    return ipcRenderer.invoke("get-mic-active");
+  },
   getMuteOnMicActive: (): Promise<boolean> => {
     return ipcRenderer.invoke("get-mute-on-mic-active");
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,9 +240,10 @@ function App() {
     }
   }, [setVolumeScale]);
 
-  // Load muteOnMicActive setting and listen for changes
+  // Load muteOnMicActive setting, initial mic state, and listen for changes
   useEffect(() => {
     window.electron?.getMuteOnMicActive?.().then(setMuteOnMicActive);
+    window.electron?.getMicActive?.().then(setMicActive);
 
     const cleanups: (() => void)[] = [];
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -32,6 +32,7 @@ declare global {
       notifyVolumeChanged: (volumeScale: number) => void;
       playTestSpeech: () => void;
       onPlayTestSpeech: (callback: () => void) => () => void;
+      getMicActive: () => Promise<boolean>;
       getMuteOnMicActive: () => Promise<boolean>;
       setMuteOnMicActive: (value: boolean) => Promise<boolean>;
       getDefaultEnginePath: (engineType: "aivis" | "voicevox") => Promise<string>;


### PR DESCRIPTION
## Summary

- Add `getMicActive` IPC handler to query the current mic active state on app startup
- Fix issue where initial mic state was not reflected in the UI, causing mute state mismatch

## Background

The `mic-active-changed` event is sent only when the mic state changes, not on initial load. This meant that if the mic was already active when the app started, the UI would not reflect the correct mute state until the mic state changed for the first time.

## Changes

- Add `get-mic-active` IPC handler in main process
- Expose `getMicActive` method in preload script
- Call `getMicActive` on app startup to get initial state
- Add TypeScript type definitions for the new method

## Test plan

- [ ] Start the app while another app is using the microphone
- [ ] Verify that the character is muted from the beginning (if "mute on mic active" is enabled)
- [ ] Stop the other app using the microphone
- [ ] Verify that the character becomes unmuted

---

Written-By: Claude Opus 4.6