### PR TITLE
自動アップデートのチェック間隔を改善

### DIFF
--- a/electron/autoUpdater.ts
+++ b/electron/autoUpdater.ts
@@ -86,11 +86,20 @@ export function initAutoUpdater(): void {
 
   setupEventHandlers();
 
-  // Delay initial check to allow UI to initialize
+  // Check every 24 hours (1 day)
+  const CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+
+  // Initial check with delay to allow UI to initialize
   setTimeout(() => {
     console.log("[AutoUpdater] Checking for updates...");
     autoUpdater.checkForUpdates();
-  }, 10_000);
+  }, 5_000);
+
+  // Periodic check every 24 hours
+  setInterval(() => {
+    console.log("[AutoUpdater] Scheduled daily update check...");
+    autoUpdater.checkForUpdates();
+  }, CHECK_INTERVAL);
 }
 
 export function checkForUpdatesManually(): void {


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

自動アップデートのチェック間隔を改善しました。

- 初回チェックの遅延時間を10秒から5秒に短縮
- 24時間ごとの定期チェックを追加実装

これにより、アプリ起動後により早くアップデートチェックが行われ、かつ定期的なチェックで常に最新バージョンを維持できるようになります。

## :camera: なぜやったのか（背景・目的）

以前の実装では、アプリ起動時に1回だけチェックを行うのみで、その後は自動的にチェックされませんでした。また、初回チェックの遅延が10秒とやや長く、ユーザー体験が損なわれていました。

今回の改善で以下を実現します：

- **初回チェックの高速化**: 遅延を10秒→5秒に短縮し、より早くアップデート通知を表示
- **定期チェックの追加**: 24時間ごとに自動チェックを行い、常に最新版を使用可能に
- **ユーザー体験の向上**: 起動直後の待機時間を短縮しつつ、継続的なセキュリティ更新を保証

## :bookmark: 関連URL

---

Written-By: Claude Sonnet 4.5