### PR TITLE
refactor: 設定画面のUI表現を改善

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -196,12 +196,12 @@ const createTray = () => {
             `Chrome: v${process.versions.chrome}`,
             `Node.js: v${process.versions.node}`,
           ].join("\n"),
-          buttons: ["ライセンス情報", "アップデートを確認", "OK"],
+          buttons: ["閉じる", "アップデートを確認", "ライセンス情報"],
         });
-        if (response === 0) {
-          createLicenseWindow();
-        } else if (response === 1) {
+        if (response === 1) {
           checkForUpdatesManually();
+        } else if (response === 2) {
+          createLicenseWindow();
         }
       },
     },

--- a/src/SettingsApp.tsx
+++ b/src/SettingsApp.tsx
@@ -471,9 +471,9 @@ export default function SettingsApp() {
                   onChange={(e) => handleEnableIdleAnimationsChange(e.target.checked)}
                   className="w-4 h-4 m-0 cursor-pointer accent-primary"
                 />
-                <span className="font-normal">ランダム待機アニメーションを使用する</span>
+                <span className="font-normal">待機モーションを有効にする</span>
               </label>
-              <p className="text-sm text-gray-400 m-0">30〜60秒ごとにランダムな待機アニメーションを再生します</p>
+              <p className="text-sm text-gray-400 m-0">待機中にたまにリアクションを取ります</p>
             </div>
             <div className="flex flex-col gap-3">
               <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-800">
@@ -483,9 +483,9 @@ export default function SettingsApp() {
                   onChange={(e) => handleEnableSpeechAnimationsChange(e.target.checked)}
                   className="w-4 h-4 m-0 cursor-pointer accent-primary"
                 />
-                <span className="font-normal">発話アニメーションを使用する</span>
+                <span className="font-normal">発話モーションを有効にする</span>
               </label>
-              <p className="text-sm text-gray-400 m-0">発話時に感情に合わせたアニメーションを再生します</p>
+              <p className="text-sm text-gray-400 m-0">発話時に感情に合わせたリアクションを取ります</p>
             </div>
           </div>
         </div>
@@ -648,7 +648,7 @@ export default function SettingsApp() {
                   <span className="font-normal">マイク使用中はミュートにする</span>
                 </label>
                 <p className="text-sm text-gray-400 m-0">
-                  他のアプリがマイクを使用中は、キャラクターの発話音声をミュートにします
+                  マイク使用中は、キャラクターの発話音声をミュートにします
                 </p>
               </div>
             )}
@@ -663,7 +663,7 @@ export default function SettingsApp() {
                 <span className="font-normal">サブエージェントの発言も含める</span>
               </label>
               <p className="text-sm text-gray-400 m-0">
-                Claudeが実行するサブエージェント（ファイル検索など）の発言も音声化します
+                サブエージェントの内容も発話の対象とします
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
設定画面の各種説明文を、より簡潔でわかりやすい表現に改善しました。

- バージョン情報ダイアログのボタン順序を変更（「閉じる」を左端に配置し、より直感的な操作に）
- アニメーション設定の説明文を「〜を使用する」から「〜を有効にする」に統一
- 説明文を短縮し、より読みやすく（「待機中にたまにリアクションを取ります」など）

## Test plan
- [x] 設定画面のアニメーション設定項目の説明文が適切に表示されることを確認
- [x] バージョン情報ダイアログのボタンが左から「閉じる」「アップデートを確認」「ライセンス情報」の順に表示されることを確認
- [x] マイクミュート・サブエージェント設定の説明文が適切に表示されることを確認

---

Written-By: Claude Sonnet 4.5