### PR TITLE
ランディングページにGitHubリンクボタンを追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,20 @@
     <section
       class="section-hero relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 py-20"
     >
+      <!-- GitHub Link -->
+      <a
+        href="https://github.com/kazakago/cc-mascot"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="absolute right-4 top-4 z-10 flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-700 text-slate-700 shadow-md backdrop-blur-sm transition-all hover:bg-white hover:shadow-lg"
+      >
+        <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+          <path
+            d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"
+          />
+        </svg>
+        GitHub
+      </a>
       <div class="fade-in relative z-10 mx-auto max-w-5xl text-center">
         <img src="icon.png" alt="cc-mascot アイコン" class="mx-auto mb-8 h-28 w-28 rounded-3xl drop-shadow-lg" />
         <h1 class="mb-4 text-5xl font-900 tracking-tight md:text-6xl">cc-mascot</h1>


### PR DESCRIPTION
## Summary

ランディングページの右上にGitHubリポジトリへのリンクボタンを追加しました。

- 半透明の白背景とバックドロップブラー効果でモダンなデザイン
- GitHubアイコン付きで視認性が高い
- ホバー時のアニメーション効果で操作性を向上

## Test plan

- [x] ランディングページ（docs/index.html）を開いて右上にGitHubボタンが表示されることを確認
- [x] ボタンをクリックしてGitHubリポジトリに正しく遷移することを確認
- [x] ホバー時のアニメーション効果が動作することを確認
- [x] レスポンシブデザインで各種画面サイズでも正しく表示されることを確認

---

Written-By: Claude Sonnet 4.5