### PR TITLE
CLAUDE_CONFIG_DIR環境変数のサポートを追加

### DIFF
--- a/electron/logMonitor.ts
+++ b/electron/logMonitor.ts
@@ -21,7 +21,8 @@ type BroadcastFn = (message: string) => void;
  * @param includeSubAgents - Whether to monitor sub-agent logs (depth: 3) or only main agent (depth: 1)
  */
 export function createLogMonitor(broadcast: BroadcastFn, includeSubAgents = false) {
-  const claudeProjectsDir = path.join(os.homedir(), ".claude", "projects");
+  const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  const claudeProjectsDir = path.join(claudeConfigDir, "projects");
 
   const watcher = chokidar.watch(claudeProjectsDir, {
     ignored: (path, stats) => stats?.isFile() === true && !path.endsWith(".jsonl"), // only watch jsonl files


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- ログ監視のベースディレクトリが`CLAUDE_CONFIG_DIR`環境変数を参照するように変更
- 環境変数が設定されていない場合は従来通り`~/.claude`を使用

## :camera: なぜやったのか（背景・目的）

Claude Code CLIは`CLAUDE_CONFIG_DIR`環境変数を使用することで、デフォルトの`~/.claude`以外のディレクトリを設定ディレクトリとして使用できるわ。

しかし、cc-mascotはログ監視のベースディレクトリがハードコードされており、環境変数による切り替えに対応していなかったの。これにより、Claude Code側で`CLAUDE_CONFIG_DIR`を設定してもcc-mascotが正しいログファイルを監視できない状態だったわ。

この変更により、Claude Codeと同じロジックで設定ディレクトリを解決するようになるため、環境変数を使用したカスタムディレクトリ運用が可能になるわよ。

## :bookmark: 関連URL

---

Written-By: Claude Sonnet 4.5