### PR TITLE
デバッグコード周りをクリーンアップ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,7 @@ IPC通信:
 - `get/set-enable-speech-animations`: レンダラー↔メイン（発話アニメーション設定・永続化のみ）
 - `reset-all-settings`: レンダラー→メイン（全設定リセット）
 - `toggle-settings-panel`: メイン→レンダラー（トレイメニューからの設定パネル表示切替）
-- `toggle-devtools` / `get-devtools-state`: レンダラー↔メイン（DevTools制御、メインウィンドウのみ）
+- `open-devtools`: レンダラー→メイン（DevToolsを開く）
 - `devtools-state-changed`: メイン→レンダラー（DevTools状態変化通知）
 
 ### 8. マイク使用中ミュート（macOS / Windows）

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -486,7 +486,6 @@ const createWindow = () => {
     console.log("[Main] DevTools opened, disabling always-on-top and resizing to avoid menu bar");
     mainWindow?.setAlwaysOnTop(false);
     mainWindow?.webContents.send("devtools-state-changed", true);
-
     // Resize window to avoid menu bar area on macOS
     if (mainWindow && !mainWindow.isDestroyed()) {
       const primaryDisplay = screen.getPrimaryDisplay();
@@ -500,7 +499,6 @@ const createWindow = () => {
     console.log("[Main] DevTools closed, enabling always-on-top and resizing to full screen");
     mainWindow?.setAlwaysOnTop(true, "pop-up-menu");
     mainWindow?.webContents.send("devtools-state-changed", false);
-
     // Resize window to cover menu bar area on macOS
     if (mainWindow && !mainWindow.isDestroyed()) {
       const primaryDisplay = screen.getPrimaryDisplay();
@@ -797,25 +795,11 @@ ipcMain.handle("reset-all-settings", async () => {
   return started;
 });
 
-// Toggle DevTools for main window
-ipcMain.handle("toggle-devtools", (_event, target: "main") => {
-  if (target === "main" && mainWindow && !mainWindow.isDestroyed()) {
-    if (mainWindow.webContents.isDevToolsOpened()) {
-      mainWindow.webContents.closeDevTools();
-    } else {
-      mainWindow.webContents.openDevTools();
-    }
-    return mainWindow.webContents.isDevToolsOpened();
+// Open DevTools for main window
+ipcMain.handle("open-devtools", () => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.openDevTools();
   }
-  return false;
-});
-
-// Get DevTools state for main window
-ipcMain.handle("get-devtools-state", (_event, target: "main") => {
-  if (target === "main") {
-    return mainWindow?.webContents.isDevToolsOpened() ?? false;
-  }
-  return false;
 });
 
 // Get current mic active state (for initial state query from renderer)

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -105,17 +105,12 @@ contextBridge.exposeInMainWorld("electron", {
       callback(isOpen);
     };
     ipcRenderer.on("devtools-state-changed", listener);
-
-    // Return cleanup function
     return () => {
       ipcRenderer.removeListener("devtools-state-changed", listener);
     };
   },
-  toggleDevTools: (target: "main"): Promise<boolean> => {
-    return ipcRenderer.invoke("toggle-devtools", target);
-  },
-  getDevToolsState: (target: "main"): Promise<boolean> => {
-    return ipcRenderer.invoke("get-devtools-state", target);
+  openDevTools: (): Promise<void> => {
+    return ipcRenderer.invoke("open-devtools");
   },
   onToggleSettingsPanel: (callback: () => void) => {
     const listener = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -584,42 +584,6 @@ function App() {
             </Scene>
           </Canvas>
 
-          {/* TEST: Local size slider with mode toggle - only shown when DevTools is open */}
-          {devToolsOpen && (
-            <div
-              style={{
-                position: "absolute",
-                bottom: 10,
-                left: "50%",
-                transform: "translateX(-50%)",
-                zIndex: 9999,
-                background: "rgba(0,0,0,0.7)",
-                padding: "8px 16px",
-                borderRadius: 8,
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: 6,
-                pointerEvents: "auto",
-              }}
-            >
-              <span style={{ color: "white", fontSize: 12 }}>{containerSize}px</span>
-              <input
-                type="range"
-                min={400}
-                max={1200}
-                step={10}
-                value={containerSize}
-                onChange={(e) => {
-                  const newSize = Number(e.target.value);
-                  containerSizeRef.current = newSize;
-                  setContainerSize(newSize);
-                }}
-                style={{ width: 250 }}
-              />
-            </div>
-          )}
-
           {/* Visualize draggable area when DevTools is open */}
           {devToolsOpen && (
             <svg

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -12,13 +12,7 @@ export function Scene({ children }: SceneProps) {
       <directionalLight position={[1, 1, 1]} intensity={1.6} />
       {children}
       <EffectComposer>
-        <Bloom
-          luminanceThreshold={1.0}
-          luminanceSmoothing={0.2}
-          mipmapBlur
-          intensity={1.0}
-          radius={0.7}
-        />
+        <Bloom luminanceThreshold={1.0} luminanceSmoothing={0.2} mipmapBlur intensity={1.0} radius={0.7} />
       </EffectComposer>
     </>
   );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -62,7 +62,6 @@ export default function SettingsPanel({
   const [testAudioError, setTestAudioError] = useState("");
   const [micMonitorAvailable, setMicMonitorAvailable] = useState(false);
   const [includeSubAgents, setIncludeSubAgents] = useState(false);
-  const [devToolsOpen, setDevToolsOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -142,21 +141,6 @@ export default function SettingsPanel({
       }
     };
     loadInitialValues();
-  }, []);
-
-  // Load DevTools state
-  useEffect(() => {
-    if (window.electron?.getDevToolsState) {
-      window.electron.getDevToolsState("main").then(setDevToolsOpen);
-    }
-
-    const cleanup = window.electron?.onDevToolsStateChanged?.((isOpen) => {
-      setDevToolsOpen(isOpen);
-    });
-
-    return () => {
-      cleanup?.();
-    };
   }, []);
 
   // Fetch speakers on mount
@@ -632,13 +616,14 @@ export default function SettingsPanel({
                   type="button"
                   className="px-4 py-2 rounded-xl text-sm font-medium cursor-pointer transition-all duration-200 border border-slate-200 bg-white text-slate-700 w-fit hover:bg-slate-50 hover:border-slate-300 hover:shadow-sm"
                   onClick={() => {
-                    window.electron?.toggleDevTools?.("main").then(setDevToolsOpen);
+                    window.electron?.openDevTools?.();
                   }}
                 >
-                  DevTools を{devToolsOpen ? "閉じる" : "開く"}
+                  DevTools を開く
                 </button>
                 <p className="text-sm text-slate-500 m-0">
-                  ショートカット: {navigator.platform.includes("Mac") ? "⌘ Command + ⌥ Option + I" : "Ctrl + Shift + I"}
+                  ショートカット:{" "}
+                  {navigator.userAgent.includes("Mac") ? "⌘ Command + ⌥ Option + I" : "Ctrl + Shift + I"}
                 </p>
               </div>
             </div>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -33,8 +33,7 @@ declare global {
       setEnableSpeechAnimations: (value: boolean) => Promise<boolean>;
       onMicActiveChanged: (callback: (active: boolean) => void) => () => void;
       onDevToolsStateChanged: (callback: (isOpen: boolean) => void) => () => void;
-      toggleDevTools: (target: "main") => Promise<boolean>;
-      getDevToolsState: (target: "main") => Promise<boolean>;
+      openDevTools: () => Promise<void>;
       onToggleSettingsPanel: (callback: () => void) => () => void;
     };
   }


### PR DESCRIPTION
## :memo: なにをやったか(変更の概要)

デバッグ機能関連のコードをクリーンアップし、開発時のDevTools操作をシンプルにしました。

- DevToolsのトグル機能を削除し、開く機能のみに変更
- 設定パネルのDevTools開閉ボタンを「開く」のみに変更
- ローカルサイズスライダー(テスト用UI)を削除
- 不要なDevTools状態の購読処理を削除
- IPC通信のインターフェースを簡素化(`toggle-devtools` / `get-devtools-state` → `open-devtools`)
- フォーマット・インデントの調整

## :camera: なぜやったのか(背景・目的)

DevToolsは開発時にキーボードショートカットで開閉することがほとんどであり、UIからのトグル機能は実質的に不要でした。また、テスト用に追加していたローカルサイズスライダーも開発フェーズが進み不要になったため削除しました。これにより以下の効果が期待できます。

- コードの見通しが良くなる
- IPC通信の複雑さが軽減される
- 設定パネルのUIがシンプルになる
- 開発者がキーボードショートカットの利用を意識しやすくなる

## :bookmark: 関連URL

---

Written-By: Claude Sonnet 4.5