### PR TITLE
テキストを文単位に分割して音声合成する機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,13 @@
   ↓
 行ごとにJSONLパース (claudeCodeParser)
   ↓
-テキストフィルタリング (textFilter)
+テキストフィルタリング (textFilter.cleanTextForSpeech)
   ↓
-感情判定 (ruleBasedEmotionClassifier)
+文単位に分割 (textFilter.splitIntoSentences)
   ↓
-IPC送信 (speak イベント)
+文ごとに感情判定 (ruleBasedEmotionClassifier)
+  ↓
+文ごとにIPC送信 (speak イベント)
 ```
 
 ### 2. JSONL解析・感情判定
@@ -199,6 +201,14 @@ IPC送信 (speak イベント)
 - コロン除去
 - かっこの読み上げ変換（`()` `（）` → 「かっこ」「かっこ閉じ」、前後にスペース付与）
 
+文分割処理（splitIntoSentences）:
+
+- フィルタリング後のテキストを文単位に分割して個別に音声合成する
+- 分割ポイント: 句点（。）、感嘆符（！!）、疑問符（？?）、改行
+- 句読点は前の文に付与（後読み分割）
+- 空文字列は保持（分節の区切り情報として）、broadcastはスキップ
+- 分割後の各文に対して感情判定を再実行（文単位の方が精度が高い）
+
 ### 3. 音声合成システム
 
 **src/hooks/useSpeech.ts**
@@ -206,9 +216,18 @@ IPC送信 (speak イベント)
 設計方針:
 
 - キュー構造で順序保証（オーバーラップなし）
+- 音声合成は並列実行（キューに入った時点で即座にAPI呼び出し）
+- 再生は必ずID順（合成が先に完了しても前のアイテムの合成完了を待つ）
 - AudioContext初期化（Electron用に自動resume）
 - エラー時もキュー継続
 - volumeScale適用（GainNode）
+
+順序保証の仕組み:
+
+- 各アイテムにインクリメンタルIDを付与
+- processQueueでキュー内の最小IDを確認
+- 最小IDがpending/synthesizing状態なら再生を開始せず待機
+- これにより短い文の合成が先に完了しても、長い文を追い越して再生されない
 
 Web Audio APIグラフ:
 

--- a/electron/filters/textFilter.test.ts
+++ b/electron/filters/textFilter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { cleanTextForSpeech } from "./textFilter";
+import { cleanTextForSpeech, splitIntoSentences } from "./textFilter";
 
 describe("cleanTextForSpeech", () => {
   describe("コードブロックの除去", () => {
@@ -317,5 +317,57 @@ import { describe, it, expect } from 'vitest';
       expect(result).toContain("2行目");
       expect(result).toContain("3行目");
     });
+  });
+});
+
+describe("splitIntoSentences", () => {
+  it("句点で分割する", () => {
+    const result = splitIntoSentences("これは1文目です。これは2文目です。");
+    expect(result).toEqual(["これは1文目です。", "これは2文目です。"]);
+  });
+
+  it("感嘆符で分割する", () => {
+    const result = splitIntoSentences("すごい！本当に！");
+    expect(result).toEqual(["すごい！", "本当に！"]);
+  });
+
+  it("疑問符で分割する", () => {
+    const result = splitIntoSentences("本当ですか？はい、そうです。");
+    expect(result).toEqual(["本当ですか？", "はい、そうです。"]);
+  });
+
+  it("半角の感嘆符・疑問符で分割する", () => {
+    const result = splitIntoSentences("Really? Yes!");
+    expect(result).toEqual(["Really?", "Yes!"]);
+  });
+
+  it("改行で分割する", () => {
+    const result = splitIntoSentences("1行目\n2行目\n3行目");
+    expect(result).toEqual(["1行目", "2行目", "3行目"]);
+  });
+
+  it("句点と改行が混在する場合", () => {
+    const result = splitIntoSentences("1文目です。\n2文目です。");
+    expect(result).toEqual(["1文目です。", "2文目です。"]);
+  });
+
+  it("空行を含む場合は空文字列を保持する", () => {
+    const result = splitIntoSentences("1文目です。\n\n2文目です。");
+    expect(result).toEqual(["1文目です。", "", "2文目です。"]);
+  });
+
+  it("空文字列は空文字列1つの配列を返す", () => {
+    const result = splitIntoSentences("");
+    expect(result).toEqual([""]);
+  });
+
+  it("句読点がない単一テキストはそのまま返す", () => {
+    const result = splitIntoSentences("句読点なしのテキスト");
+    expect(result).toEqual(["句読点なしのテキスト"]);
+  });
+
+  it("前後の空白をトリムする", () => {
+    const result = splitIntoSentences("  1文目です。  2文目です。  ");
+    expect(result).toEqual(["1文目です。", "2文目です。", ""]);
   });
 });

--- a/electron/filters/textFilter.ts
+++ b/electron/filters/textFilter.ts
@@ -46,3 +46,15 @@ export function cleanTextForSpeech(text: string): string {
 
   return cleaned;
 }
+
+/**
+ * Split text into individual sentences for sequential speech synthesis.
+ * Splits on Japanese period (。), exclamation (！/!), question (？/?), and newlines.
+ * Returns trimmed sentences (including empty strings as spacing information).
+ */
+export function splitIntoSentences(text: string): string[] {
+  // Split on sentence-ending punctuation (keeping the punctuation attached) and newlines
+  const parts = text.split(/(?<=[。！？!?])|[\n\r]+/);
+
+  return parts.map((s) => s.trim());
+}

--- a/electron/logMonitor.test.ts
+++ b/electron/logMonitor.test.ts
@@ -24,6 +24,15 @@ vi.mock("./parsers/claudeCodeParser", () => ({
 
 vi.mock("./filters/textFilter", () => ({
   cleanTextForSpeech: vi.fn(),
+  splitIntoSentences: vi.fn((text: string) => [text]),
+}));
+
+vi.mock("./services/ruleBasedEmotionClassifier", () => ({
+  RuleBasedEmotionClassifier: class {
+    classify() {
+      return "neutral";
+    }
+  },
 }));
 
 import { createLogMonitor } from "./logMonitor";
@@ -369,7 +378,7 @@ describe("logMonitor", () => {
       expect(parseClaudeCodeLog).toHaveBeenCalled();
       expect(cleanTextForSpeech).toHaveBeenCalledWith("こんにちは！");
       expect(mockBroadcast).toHaveBeenCalledWith(
-        JSON.stringify({ type: "speak", text: "こんにちは！", emotion: "happy" }),
+        JSON.stringify({ type: "speak", text: "こんにちは！", emotion: "neutral" }),
       );
     });
 

--- a/electron/logMonitor.ts
+++ b/electron/logMonitor.ts
@@ -4,7 +4,8 @@ import * as path from "path";
 import * as os from "os";
 import * as readline from "readline";
 import { parseClaudeCodeLog, SpeakMessage } from "./parsers/claudeCodeParser";
-import { cleanTextForSpeech } from "./filters/textFilter";
+import { cleanTextForSpeech, splitIntoSentences } from "./filters/textFilter";
+import { RuleBasedEmotionClassifier } from "./services/ruleBasedEmotionClassifier";
 
 // Track file positions to avoid re-reading
 const filePositions = new Map<string, number>();
@@ -12,6 +13,9 @@ const filePositions = new Map<string, number>();
 // Debounce map to prevent rapid-fire speech
 const lastProcessed = new Map<string, number>();
 const DEBOUNCE_MS = 100;
+
+// Emotion classifier for per-sentence re-classification
+const emotionClassifier = new RuleBasedEmotionClassifier();
 
 type BroadcastFn = (message: string) => void;
 
@@ -148,14 +152,26 @@ function processLogLine(line: string, broadcast: BroadcastFn, includeSubAgents: 
     const cleanedText = cleanTextForSpeech(message.text);
 
     if (cleanedText) {
-      console.log(`[LogMonitor] Extracted text: ${cleanedText.substring(0, 50)}...`);
+      // Split into sentences for faster sequential speech synthesis
+      const sentences = splitIntoSentences(cleanedText);
 
-      broadcast(
-        JSON.stringify({
-          ...message,
-          text: cleanedText,
-        }),
-      );
+      for (const sentence of sentences) {
+        // Skip empty sentences (e.g. from blank lines between paragraphs)
+        if (!sentence) continue;
+
+        // Re-classify emotion per sentence for more accurate expression
+        const emotion = emotionClassifier.classify(sentence);
+
+        console.log(`[LogMonitor] Extracted text: ${sentence.substring(0, 50)}...`);
+
+        broadcast(
+          JSON.stringify({
+            ...message,
+            text: sentence,
+            emotion,
+          }),
+        );
+      }
     }
   }
 }

--- a/src/hooks/useSpeech.ts
+++ b/src/hooks/useSpeech.ts
@@ -96,12 +96,17 @@ export function useSpeech({ onStart, onEnd, speakerId, baseUrl, volumeScale, isM
       return;
     }
 
-    // 次に発話すべきアイテムを探す（ID順）
+    // 次に発話すべきアイテムを探す（ID順、合成中のアイテムより先には進まない）
     let nextItem: QueueItem | undefined;
+    let smallestId = Infinity;
     for (const [id, item] of queueRef.current) {
-      if (item.status === "ready") {
-        // まだ再生していない最も小さいIDのアイテムを再生
-        if (!nextItem || id < nextItem.id) {
+      if (id < smallestId) {
+        smallestId = id;
+        // 最小IDのアイテムがまだ合成中なら、順番を守って待つ
+        if (item.status === "pending" || item.status === "synthesizing") {
+          return;
+        }
+        if (item.status === "ready") {
           nextItem = item;
         }
       }


### PR DESCRIPTION
## Summary

- `textFilter.ts` に `splitIntoSentences` 関数を追加し、テキストを句点（。）・感嘆符（！/!）・疑問符（？/?）・改行で文単位に分割する
- `logMonitor.ts` でテキスト全体ではなく文単位でIPC送信するよう変更し、各文ごとに感情判定を再実行することで精度を向上
- `useSpeech.ts` の順序保証ロジックを改善し、短い文の合成が先に完了しても長い文を追い越して再生されないよう最小IDチェックを追加
- `textFilter.test.ts` に `splitIntoSentences` のテストケースを追加

## Motivation

長いテキストを一括して合成する場合、合成が完了するまで発話が開始されず応答が遅く感じられた。文単位に分割して並列合成・順序制御することで最初の文の発話開始を早め、体感的な応答速度を向上させる。

## Test plan

- [ ] `npm run test:run` で既存テスト261件がすべて通過することを確認
- [ ] Claude Codeの応答で文ごとに順番通り発話されることを確認
- [ ] 感情表現が各文に適切に反映されることを確認
- [ ] 短い文が先に合成されても再生順序が前の文を追い越さないことを確認

---

Written-By: claude-sonnet-4-5-20250929