### PR TITLE
毎フレームスプリングボーンをリセットして髪や衣装の反転を防止

### DIFF
--- a/src/components/VRMAvatar.tsx
+++ b/src/components/VRMAvatar.tsx
@@ -107,6 +107,11 @@ export const VRMAvatar = forwardRef<VRMAvatarHandle, VRMAvatarProps>(function VR
   useFrame((_, delta) => {
     updateAnimation(delta);
     applyDefaultFingerPose();
+
+    // Reset spring bones every frame before VRM update to prevent
+    // hair/skirt flipping (e.g. on initial load or animation switch)
+    vrm?.springBoneManager?.reset();
+
     updateVRM(delta);
 
     // Update head position for visualization


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

VRMキャラクターの髪や衣装（スカートなど）が反転・めり込む問題を修正しました。
`VRMAvatar.tsx` の毎フレーム処理に `vrm?.springBoneManager?.reset()` の呼び出しを追加し、VRMモデルのアップデート前に毎フレームスプリングボーンをリセットするようにしました。

## :camera: なぜやったのか（背景・目的）

VRMモデルの初回読み込み時やアニメーション切り替え時に、スプリングボーン（物理演算で動く髪や衣装）が反転・めり込む現象が発生していた。
毎フレームのVRM更新前にスプリングボーンをリセットすることで、この問題を解消できる。

## :bookmark: 関連URL

---

Written-By: claude-sonnet-4-5-20250929