### PR TITLE
LPのStep 2説明文とフッターを更新

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -320,7 +320,7 @@
           <div class="rounded-2xl bg-white/80 p-6 shadow-md backdrop-blur-sm">
             <div class="mb-2 text-sm font-700 text-pink-500">Step 2</div>
             <h3 class="mb-2 font-700">アプリをインストール</h3>
-            <p class="text-sm text-slate-600">GitHubリリースページから最新バイナリをダウンロード&インストール。</p>
+            <p class="text-sm text-slate-600">本サイト、またはGitHub Releasesからアプリをダウンロード&インストール。</p>
           </div>
           <div class="rounded-2xl bg-white/80 p-6 shadow-md backdrop-blur-sm">
             <div class="mb-2 text-sm font-700 text-violet-500">Step 3</div>
@@ -364,22 +364,23 @@
 
     <!-- Footer -->
     <footer class="section-footer border-t border-slate-200/50 px-4 py-12">
-      <div class="mx-auto max-w-4xl text-center">
+      <div class="mx-auto max-w-4xl">
         <div class="mb-6 flex items-center justify-center gap-2">
           <img src="icon.png" alt="cc-mascot" class="h-8 w-8 rounded-lg" />
           <span class="text-lg font-700">cc-mascot</span>
         </div>
-        <div class="mb-6 flex flex-wrap justify-center gap-6 text-sm text-slate-600">
-          <a href="https://github.com/kazakago/cc-mascot" class="hover:text-slate-800">GitHub</a>
-          <a href="https://github.com/kazakago/cc-mascot/releases" class="hover:text-slate-800">Releases</a>
-          <a href="https://github.com/kazakago/cc-mascot/blob/main/LICENSE" class="hover:text-slate-800">License</a>
-          <a href="terms.html" class="hover:text-slate-800">Terms</a>
-          <a href="privacy.html" class="hover:text-slate-800">Privacy Policy</a>
+        <div class="mb-6 flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-slate-600">
+          <a href="https://github.com/kazakago/cc-mascot" target="_blank" rel="noopener noreferrer" class="hover:text-slate-800">GitHub</a>
+          <a href="terms.html" class="hover:text-slate-800">利用規約</a>
+          <a href="privacy.html" class="hover:text-slate-800">プライバシーポリシー</a>
         </div>
-        <p class="text-xs text-slate-400">
-          &copy; 2026
-          <a href="https://blog.kazakago.com/" class="hover:text-slate-600">kazakago</a>
-        </p>
+        <p class="mb-3 text-center text-sm font-700 text-slate-500">Developed by kazakago</p>
+        <div class="mb-8 flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-slate-600">
+          <a href="mailto:kazakago@gmail.com" class="hover:text-slate-800">Email</a>
+          <a href="https://x.com/kazakago" target="_blank" rel="noopener noreferrer" class="hover:text-slate-800">X (Twitter)</a>
+          <a href="https://blog.kazakago.com/" target="_blank" rel="noopener noreferrer" class="hover:text-slate-800">Blog</a>
+        </div>
+        <p class="text-center text-xs text-slate-400">&copy; 2026 kazakago</p>
       </div>
     </footer>
 


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- Step 2の説明文を「GitHubリリースページから最新バイナリをダウンロード&インストール。」から「本サイト、またはGitHub Releasesからアプリをダウンロード&インストール。」に変更
- フッターのレイアウトを更新
  - `text-center` をコンテナから分離し、各要素に個別に適用するよう調整
  - フッターリンクの整理（GitHub、利用規約、プライバシーポリシーのみに絞り込み）
  - GitHubリンクに `target="_blank" rel="noopener noreferrer"` を追加
  - 開発者情報セクションを追加（Email、X (Twitter)、Blog へのリンク）
  - コピーライト表記を `&copy; 2026 kazakago` に統一

## :camera: なぜやったのか（背景・目的）

- Step 2の説明文がGitHubリリースページのみを案内していたが、本サイトにもダウンロードボタンがあるためより正確な案内に修正
- フッターの情報を充実させ、開発者への連絡手段や関連ページへのアクセスを改善

## :bookmark: 関連URL

---

Written-By: claude-sonnet-4-6