### PR TITLE
モーションの雰囲気フィルタを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,9 +345,13 @@ VRM読み込み:
 - VRMAnimationLoaderPlugin使用
 - ループ再生対応
 - デフォルト: `/animations/idle_loop.vrma`（待機ループモーション）
-- 待機アニメーション: `/animations/idle_anim1〜4.vrma`（ランダム再生）
-- 感情別アニメーション: `/animations/happy1.vrma`, `/animations/happy2.vrma`, `/animations/angry.vrma`, `/animations/sad.vrma`, `/animations/relaxed.vrma`
+- 待機アニメーション: `/animations/idle/*.vrma` と `/animations/proprietary/idle/*.vrma` からランダム再生
+- 感情別アニメーション: `/animations/<emotion>/*.vrma` と `/animations/proprietary/<emotion>/*.vrma` からランダム再生
 - `enableIdleAnimations` / `enableSpeechAnimations` 設定で有効/無効を切替可能
+- `includeCoolAnimations` / `includeCuteAnimations` 設定でモーションの雰囲気をフィルタ可能
+- ファイル名が `__cool.vrma` で終わるモーションはクール系、`__cute.vrma` で終わるモーションはかわいい系として扱う
+- `__cool.vrma` / `__cute.vrma` 以外のモーションはナチュラル扱いで常に候補に含まれる
+- 同じVRMAを連続で再生する場合でも再生トリガーが走るよう、URLとは別に `animationPlayKey` を更新する
 
 **src/hooks/useBlink.ts**
 
@@ -424,6 +428,8 @@ IPC通信:
 - `get/set-auto-update-check`: レンダラー↔メイン（起動時アップデート確認・永続化のみ）
 - `get/set-enable-idle-animations`: レンダラー↔メイン（待機アニメーション設定・永続化のみ）
 - `get/set-enable-speech-animations`: レンダラー↔メイン（発話アニメーション設定・永続化のみ）
+- `get/set-include-cool-animations`: レンダラー↔メイン（クール系モーションを候補に含めるか）
+- `get/set-include-cute-animations`: レンダラー↔メイン（かわいい系モーションを候補に含めるか）
 - `get/set-speaker-id`: レンダラー↔メイン（話者ID・永続化のみ）
 - `get/set-volume-scale`: レンダラー↔メイン（音量スケール・永続化のみ）
 - `get-active-session`: レンダラー→メイン（現在のセッションフィルタID取得）
@@ -624,6 +630,8 @@ claude --plugin-dir ./plugin
 | `muteOnMicActive`        | boolean | false      | マイク使用中にミュートするか            |
 | `enableIdleAnimations`   | boolean | true       | 待機アニメーションの有効/無効           |
 | `enableSpeechAnimations` | boolean | true       | 発話アニメーションの有効/無効           |
+| `includeCoolAnimations`  | boolean | true       | クール系モーションを候補に含めるか      |
+| `includeCuteAnimations`  | boolean | true       | かわいい系モーションを候補に含めるか    |
 | `speakerId`              | number  | 888753760  | 話者ID（AivisSpeechデフォルト）         |
 | `volumeScale`            | number  | 1.0        | 音量スケール（0.0〜2.0）                |
 | `autoUpdateCheck`        | boolean | true       | 起動時にアップデートを確認するか        |
@@ -825,6 +833,14 @@ Gitサブモジュールとして `public/animations/proprietary/` に直接配�
 
 - `public/animations/<category>/` （公開アニメーション）
 - `public/animations/proprietary/<category>/` （プライベートアニメーション）
+
+モーションの雰囲気分類はファイル名の拡張子直前サフィックスで判定します。
+
+- `__cool.vrma`: クール系モーション（`includeCoolAnimations` が有効な場合のみ候補）
+- `__cute.vrma`: かわいい系モーション（`includeCuteAnimations` が有効な場合のみ候補）
+- 上記以外: ナチュラルなモーション（常に候補）
+
+例: `happy/v_sign__cute.vrma` はかわいい系、`happy/thankful.vrma` はナチュラル扱い。
 
 > **注意:** プライベートリポジトリへのアクセス権がない場合は公開アニメーションのみ動作します。
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -860,6 +860,8 @@ ipcMain.handle("reset-all-settings", async () => {
   store.delete("muteOnMicActive");
   store.delete("enableIdleAnimations");
   store.delete("enableSpeechAnimations");
+  store.delete("includeCoolAnimations");
+  store.delete("includeCuteAnimations");
   store.delete("speakerId");
   store.delete("volumeScale");
   store.delete("autoUpdateCheck");
@@ -961,6 +963,26 @@ ipcMain.handle("get-enable-speech-animations", () => {
 
 ipcMain.handle("set-enable-speech-animations", (_event, value: boolean) => {
   store.set("enableSpeechAnimations", value);
+  return true;
+});
+
+ipcMain.handle("get-include-cool-animations", () => {
+  const value = store.get("includeCoolAnimations");
+  return value === undefined ? true : (value as boolean);
+});
+
+ipcMain.handle("set-include-cool-animations", (_event, value: boolean) => {
+  store.set("includeCoolAnimations", value);
+  return true;
+});
+
+ipcMain.handle("get-include-cute-animations", () => {
+  const value = store.get("includeCuteAnimations");
+  return value === undefined ? true : (value as boolean);
+});
+
+ipcMain.handle("set-include-cute-animations", (_event, value: boolean) => {
+  store.set("includeCuteAnimations", value);
   return true;
 });
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -97,6 +97,18 @@ contextBridge.exposeInMainWorld("electron", {
   setEnableSpeechAnimations: (value: boolean): Promise<boolean> => {
     return ipcRenderer.invoke("set-enable-speech-animations", value);
   },
+  getIncludeCoolAnimations: (): Promise<boolean> => {
+    return ipcRenderer.invoke("get-include-cool-animations");
+  },
+  setIncludeCoolAnimations: (value: boolean): Promise<boolean> => {
+    return ipcRenderer.invoke("set-include-cool-animations", value);
+  },
+  getIncludeCuteAnimations: (): Promise<boolean> => {
+    return ipcRenderer.invoke("get-include-cute-animations");
+  },
+  setIncludeCuteAnimations: (value: boolean): Promise<boolean> => {
+    return ipcRenderer.invoke("set-include-cute-animations", value);
+  },
   onMicActiveChanged: (callback: (active: boolean) => void) => {
     const listener = (_event: unknown, active: boolean) => {
       callback(active);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,24 @@ const IDLE_RANDOM_MIN_INTERVAL = 30000; // 30秒
 const IDLE_RANDOM_MAX_INTERVAL = 60000; // 60秒
 const VOICEVOX_BASE_URL = "http://localhost:8564";
 
+type MotionStyle = "natural" | "cool" | "cute";
+
 // Settings panel width constant for click-through calculation
 const SETTINGS_PANEL_WIDTH = 400;
+
+function getMotionStyle(animationUrl: string): MotionStyle {
+  const fileName = animationUrl.split("/").pop() ?? animationUrl;
+  const match = fileName.match(/__(cool|cute)\.vrma$/i);
+  return match ? (match[1].toLowerCase() as MotionStyle) : "natural";
+}
+
+function filterAnimationUrls(animationUrls: string[] | undefined, includeCool: boolean, includeCute: boolean) {
+  if (!animationUrls) return [];
+  return animationUrls.filter((url) => {
+    const style = getMotionStyle(url);
+    return style === "natural" || (style === "cool" && includeCool) || (style === "cute" && includeCute);
+  });
+}
 
 function App() {
   const avatarRef = useRef<VRMAvatarHandle>(null);
@@ -49,6 +65,7 @@ function App() {
   const [vrmUrl, setVrmUrl] = useState<string>(DEFAULT_VRM_URL);
   const animationManifestRef = useRef<AnimationManifest | null>(null);
   const [currentAnimationUrl, setCurrentAnimationUrl] = useState<string>(FALLBACK_IDLE_LOOP_URL);
+  const [currentAnimationPlayKey, setCurrentAnimationPlayKey] = useState(0);
   const [currentEmotion, setCurrentEmotion] = useState<Emotion>("neutral");
   const [containerCenter, setContainerCenter] = useState({ x: 0, y: 0 });
   const [containerSize, setContainerSize] = useState(800);
@@ -60,6 +77,8 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [enableIdleAnimations, setEnableIdleAnimations] = useState(true);
   const [enableSpeechAnimations, setEnableSpeechAnimations] = useState(true);
+  const [includeCoolAnimations, setIncludeCoolAnimations] = useState(true);
+  const [includeCuteAnimations, setIncludeCuteAnimations] = useState(true);
   const [isCharacterVisible, setIsCharacterVisible] = useState(true);
 
   // ランダム待機アニメーション用ref
@@ -69,6 +88,8 @@ function App() {
   const nextIdleIntervalRef = useRef(0);
   const enableIdleAnimationsRef = useRef(true);
   const enableSpeechAnimationsRef = useRef(true);
+  const includeCoolAnimationsRef = useRef(true);
+  const includeCuteAnimationsRef = useRef(true);
   const showSettingsRef = useRef(false);
 
   // Keep refs in sync with state
@@ -92,13 +113,18 @@ function App() {
       IDLE_RANDOM_MIN_INTERVAL + Math.random() * (IDLE_RANDOM_MAX_INTERVAL - IDLE_RANDOM_MIN_INTERVAL);
   }, []);
 
+  const playAnimation = useCallback((animationUrl: string) => {
+    setCurrentAnimationUrl(animationUrl);
+    setCurrentAnimationPlayKey((key) => key + 1);
+  }, []);
+
   // アニメーションマニフェストをロード
   useEffect(() => {
     window.electron?.getAnimationManifest?.().then((manifest) => {
       animationManifestRef.current = manifest;
-      setCurrentAnimationUrl(manifest.idle_loop);
+      playAnimation(manifest.idle_loop);
     });
-  }, []);
+  }, [playAnimation]);
 
   // Cursor tracking settings (fixed values)
   const cursorTrackingOptions: Partial<CursorTrackingOptions> = useMemo(
@@ -215,6 +241,14 @@ function App() {
       setEnableSpeechAnimations(value);
       enableSpeechAnimationsRef.current = value;
     });
+    window.electron?.getIncludeCoolAnimations?.().then((value) => {
+      setIncludeCoolAnimations(value);
+      includeCoolAnimationsRef.current = value;
+    });
+    window.electron?.getIncludeCuteAnimations?.().then((value) => {
+      setIncludeCuteAnimations(value);
+      includeCuteAnimationsRef.current = value;
+    });
   }, []);
 
   // Listen for toggle-character-visibility from tray menu
@@ -256,18 +290,22 @@ function App() {
 
       // Select animation based on emotion (randomly choose from array)
       if (enableSpeechAnimationsRef.current && emotion !== "neutral") {
-        const animationUrls = animationManifestRef.current?.emotions[emotion];
+        const animationUrls = filterAnimationUrls(
+          animationManifestRef.current?.emotions[emotion],
+          includeCoolAnimationsRef.current,
+          includeCuteAnimationsRef.current,
+        );
         if (animationUrls && animationUrls.length > 0) {
           const randomIndex = Math.floor(Math.random() * animationUrls.length);
           const animationUrl = animationUrls[randomIndex];
-          setCurrentAnimationUrl(animationUrl);
+          playAnimation(animationUrl);
         }
       }
       // If disabled or no animation for this emotion, keep current animation (idle)
 
       startLipSync(analyser);
     },
-    [startLipSync],
+    [playAnimation, startLipSync],
   );
 
   const handleSpeechEnd = useCallback(() => {
@@ -284,22 +322,26 @@ function App() {
 
   const handleAnimationEnd = useCallback(() => {
     // When animation ends, return to idle and reset random idle timer
-    setCurrentAnimationUrl(animationManifestRef.current?.idle_loop ?? FALLBACK_IDLE_LOOP_URL);
+    playAnimation(animationManifestRef.current?.idle_loop ?? FALLBACK_IDLE_LOOP_URL);
     lastIdleAnimTimeRef.current = Date.now();
     nextIdleIntervalRef.current =
       IDLE_RANDOM_MIN_INTERVAL + Math.random() * (IDLE_RANDOM_MAX_INTERVAL - IDLE_RANDOM_MIN_INTERVAL);
-  }, []);
+  }, [playAnimation]);
 
   const handleAnimationLoop = useCallback(() => {
     if (isSpeakingRef.current) return;
     if (!enableIdleAnimationsRef.current) return;
     const elapsed = Date.now() - lastIdleAnimTimeRef.current;
     if (elapsed < nextIdleIntervalRef.current) return;
-    const idleUrls = animationManifestRef.current?.idle;
+    const idleUrls = filterAnimationUrls(
+      animationManifestRef.current?.idle,
+      includeCoolAnimationsRef.current,
+      includeCuteAnimationsRef.current,
+    );
     if (!idleUrls || idleUrls.length === 0) return;
     const randomIndex = Math.floor(Math.random() * idleUrls.length);
-    setCurrentAnimationUrl(idleUrls[randomIndex]);
-  }, []);
+    playAnimation(idleUrls[randomIndex]);
+  }, [playAnimation]);
 
   const { speakText } = useSpeech({
     onStart: handleSpeechStart,
@@ -390,6 +432,18 @@ function App() {
     await window.electron?.setEnableSpeechAnimations?.(value);
   }, []);
 
+  const handleIncludeCoolAnimationsChange = useCallback(async (value: boolean) => {
+    setIncludeCoolAnimations(value);
+    includeCoolAnimationsRef.current = value;
+    await window.electron?.setIncludeCoolAnimations?.(value);
+  }, []);
+
+  const handleIncludeCuteAnimationsChange = useCallback(async (value: boolean) => {
+    setIncludeCuteAnimations(value);
+    includeCuteAnimationsRef.current = value;
+    await window.electron?.setIncludeCuteAnimations?.(value);
+  }, []);
+
   const handleMuteOnMicActiveChange = useCallback(async (value: boolean) => {
     setMuteOnMicActive(value);
     await window.electron?.setMuteOnMicActive?.(value);
@@ -430,6 +484,10 @@ function App() {
     enableIdleAnimationsRef.current = true;
     setEnableSpeechAnimations(true);
     enableSpeechAnimationsRef.current = true;
+    setIncludeCoolAnimations(true);
+    includeCoolAnimationsRef.current = true;
+    setIncludeCuteAnimations(true);
+    includeCuteAnimationsRef.current = true;
 
     // Reset character position
     const screenSize = await window.electron?.getScreenSize?.();
@@ -599,6 +657,7 @@ function App() {
                 url={vrmUrl}
                 animationUrl={currentAnimationUrl}
                 animationLoop={currentAnimationUrl === FALLBACK_IDLE_LOOP_URL}
+                animationPlayKey={currentAnimationPlayKey}
                 onAnimationEnd={handleAnimationEnd}
                 onAnimationLoop={handleAnimationLoop}
                 cursorTrackingOptions={cursorTrackingOptions}
@@ -698,6 +757,10 @@ function App() {
           onEnableIdleAnimationsChange={handleEnableIdleAnimationsChange}
           enableSpeechAnimations={enableSpeechAnimations}
           onEnableSpeechAnimationsChange={handleEnableSpeechAnimationsChange}
+          includeCoolAnimations={includeCoolAnimations}
+          onIncludeCoolAnimationsChange={handleIncludeCoolAnimationsChange}
+          includeCuteAnimations={includeCuteAnimations}
+          onIncludeCuteAnimationsChange={handleIncludeCuteAnimationsChange}
           muteOnMicActive={muteOnMicActive}
           onMuteOnMicActiveChange={handleMuteOnMicActiveChange}
           onResetCharacterPosition={handleResetCharacterPosition}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -24,6 +24,10 @@ interface SettingsPanelProps {
   onEnableIdleAnimationsChange: (value: boolean) => void;
   enableSpeechAnimations: boolean;
   onEnableSpeechAnimationsChange: (value: boolean) => void;
+  includeCoolAnimations: boolean;
+  onIncludeCoolAnimationsChange: (value: boolean) => void;
+  includeCuteAnimations: boolean;
+  onIncludeCuteAnimationsChange: (value: boolean) => void;
   muteOnMicActive: boolean;
   onMuteOnMicActiveChange: (value: boolean) => void;
   onResetCharacterPosition: () => void;
@@ -44,6 +48,10 @@ export default function SettingsPanel({
   onEnableIdleAnimationsChange,
   enableSpeechAnimations,
   onEnableSpeechAnimationsChange,
+  includeCoolAnimations,
+  onIncludeCoolAnimationsChange,
+  includeCuteAnimations,
+  onIncludeCuteAnimationsChange,
   muteOnMicActive,
   onMuteOnMicActiveChange,
   onResetCharacterPosition,
@@ -581,6 +589,28 @@ export default function SettingsPanel({
                   <span className="font-normal">発話モーションを有効にする</span>
                 </label>
                 <p className="text-sm text-slate-400 m-0">発話時に感情に合わせたリアクションを取ります</p>
+              </div>
+              <div className="flex flex-col gap-3 border-t border-slate-200 pt-4">
+                <p className="text-sm font-medium text-slate-600 m-0">モーションの雰囲気</p>
+                <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-800">
+                  <input
+                    type="checkbox"
+                    checked={includeCoolAnimations}
+                    onChange={(e) => onIncludeCoolAnimationsChange(e.target.checked)}
+                    className="w-4 h-4 m-0 cursor-pointer accent-primary"
+                  />
+                  <span className="font-normal">クール系モーションを含める</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer text-sm text-slate-800">
+                  <input
+                    type="checkbox"
+                    checked={includeCuteAnimations}
+                    onChange={(e) => onIncludeCuteAnimationsChange(e.target.checked)}
+                    className="w-4 h-4 m-0 cursor-pointer accent-primary"
+                  />
+                  <span className="font-normal">かわいい系モーションを含める</span>
+                </label>
+                <p className="text-sm text-slate-400 m-0">ナチュラルなモーションは常に含まれます</p>
               </div>
             </div>
           </section>

--- a/src/components/VRMAvatar.tsx
+++ b/src/components/VRMAvatar.tsx
@@ -24,6 +24,7 @@ interface VRMAvatarProps {
   url: string;
   animationUrl?: string;
   animationLoop?: boolean;
+  animationPlayKey?: number;
   onAnimationEnd?: () => void;
   onAnimationLoop?: () => void;
   cursorTrackingOptions?: Partial<CursorTrackingOptions>;
@@ -36,6 +37,7 @@ export const VRMAvatar = forwardRef<VRMAvatarHandle, VRMAvatarProps>(function VR
     url,
     animationUrl,
     animationLoop = true,
+    animationPlayKey = 0,
     onAnimationEnd,
     onAnimationLoop,
     cursorTrackingOptions,
@@ -47,6 +49,7 @@ export const VRMAvatar = forwardRef<VRMAvatarHandle, VRMAvatarProps>(function VR
   const { vrm, bounds, loading, error, isVRM0, setMouthOpen, setEmotion, update: updateVRM } = useVRM(url);
   const { update: updateAnimation, animatedBonesRef } = useVRMAnimation(vrm, animationUrl || "", {
     loop: animationLoop,
+    playKey: animationPlayKey,
     onAnimationEnd,
     onAnimationLoop,
   });

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -39,6 +39,10 @@ declare global {
       setEnableIdleAnimations: (value: boolean) => Promise<boolean>;
       getEnableSpeechAnimations: () => Promise<boolean>;
       setEnableSpeechAnimations: (value: boolean) => Promise<boolean>;
+      getIncludeCoolAnimations: () => Promise<boolean>;
+      setIncludeCoolAnimations: (value: boolean) => Promise<boolean>;
+      getIncludeCuteAnimations: () => Promise<boolean>;
+      setIncludeCuteAnimations: (value: boolean) => Promise<boolean>;
       onMicActiveChanged: (callback: (active: boolean) => void) => () => void;
       onDevToolsStateChanged: (callback: (isOpen: boolean) => void) => () => void;
       openDevTools: () => Promise<void>;

--- a/src/hooks/useVRMAnimation.ts
+++ b/src/hooks/useVRMAnimation.ts
@@ -6,12 +6,13 @@ import type { VRM } from "@pixiv/three-vrm";
 
 interface UseVRMAnimationOptions {
   loop?: boolean;
+  playKey?: number;
   onAnimationEnd?: () => void;
   onAnimationLoop?: () => void;
 }
 
 export function useVRMAnimation(vrm: VRM | null, animationUrl: string, options: UseVRMAnimationOptions = {}) {
-  const { loop = true, onAnimationEnd, onAnimationLoop } = options;
+  const { loop = true, playKey = 0, onAnimationEnd, onAnimationLoop } = options;
   const [vrmAnimation, setVrmAnimation] = useState<VRMAnimation | null>(null);
   const mixerRef = useRef<AnimationMixer | null>(null);
   const currentActionRef = useRef<AnimationAction | null>(null);
@@ -124,7 +125,7 @@ export function useVRMAnimation(vrm: VRM | null, animationUrl: string, options: 
         mixer.removeEventListener("loop", handleLoop);
       };
     }
-  }, [vrm, vrmAnimation, loop, onAnimationEnd, onAnimationLoop]);
+  }, [vrm, vrmAnimation, loop, playKey, onAnimationEnd, onAnimationLoop]);
 
   const update = useCallback((delta: number) => {
     mixerRef.current?.update(delta);


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- 設定画面に「クール系モーションを含める」「かわいい系モーションを含める」チェックを追加
- `__cool.vrma` / `__cute.vrma` のファイル名サフィックスでモーション候補をフィルタするように変更
- 同じVRMAが連続で選ばれても再生し直せるように `animationPlayKey` を追加
- サブモジュールのアニメーション参照を更新
- `CLAUDE.md` にモーション分類ルールと関連設定を追記

## :camera: なぜやったのか（背景・目的）

キャラクターによって違和感のあるモーションを設定から簡単に除外できるようにするため。特に、男性寄り・中性的なキャラクターでかわいい系の動きが合わない場合でも、待機・発話モーション全体を無効にせず雰囲気だけ調整できるようにした。

また、候補が1件になった場合に同じモーションが連続で選ばれると再生されない問題が見つかったため、URLとは別の再生キーで確実に再トリガーできるようにした。

## :bookmark: 関連URL


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)