### PR TITLE
エージェント用スキルリンクを追加

### DIFF
--- a/.claude/skills/commit-push-pr/SKILL.md
+++ b/.claude/skills/commit-push-pr/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: commit-push-pr
 description: 変更を意味のある単位でコミットし、PRを作成します。
-argument-hint: [-b <base-branch>] [-d (draft)] [-p (prompt付与)]
+argument-hint: "[-b <base-branch>] [-d (draft)] [-p (prompt付与)]"
 model: sonnet
-context: fork
 ---
 
 # コミット・プッシュ・PR作成

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: commit
 description: 変更を意味のある単位でコミットします。
-argument-hint: [-b <base-branch>]
+argument-hint: "[-b <base-branch>]"
 model: sonnet
-context: fork
 ---
 
 # コミット作成

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: create-pr
 description: 現在のコミットからPRを作成します。
-argument-hint: [-b <base-branch>] [-d (draft)] [-p (prompt付与)]
+argument-hint: "[-b <base-branch>] [-d (draft)] [-p (prompt付与)]"
 model: sonnet
-context: fork
 ---
 
 # PRを作成

--- a/.claude/skills/export-prompt/SKILL.md
+++ b/.claude/skills/export-prompt/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: export-prompt
 description: 会話のユーザー入力のみをエクスポートします。引数なしでクリップボード、filepathを指定するとファイルに出力
-argument-hint: [filepath]
+argument-hint: "[filepath]"
 model: haiku
-context: fork
 ---
 
 # ユーザー入力のエクスポート

--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: merge-pr
 description: PRをマージして、マージ先のブランチへをチェックアウトします。
-argument-hint: [-b <target-branch>]
+argument-hint: "[-b <target-branch>]"
 model: sonnet
-context: fork
 ---
 
 ## 1. 引数のパース

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.gemini/skills
+++ b/.gemini/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- `.codex/skills` を `.claude/skills` へのシンボリックリンクとして追加
- `.gemini/skills` を `.claude/skills` へのシンボリックリンクとして追加

## :camera: なぜやったのか（背景・目的）

Claude Code 用に管理しているスキルを Codex や Gemini からも同じ内容で参照できるようにするため。

## :bookmark: 関連URL


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)