### PR TITLE
GitHub Actionsの参照を更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,20 +19,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-
-      - name: Setup SSH for private submodule
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.CC_MASCOT_PRIVATE_DEPLOY_KEY }}
-
-      - name: Initialize private submodule
-        run: git submodule update --init
+          ssh-key: ${{ secrets.CC_MASCOT_PRIVATE_DEPLOY_KEY }}
+          submodules: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"
@@ -58,7 +52,7 @@ jobs:
           APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-macos
           path: |
@@ -73,20 +67,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-
-      - name: Setup SSH for private submodule
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.CC_MASCOT_PRIVATE_DEPLOY_KEY }}
-
-      - name: Initialize private submodule
-        run: git submodule update --init
+          ssh-key: ${{ secrets.CC_MASCOT_PRIVATE_DEPLOY_KEY }}
+          submodules: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"
@@ -98,7 +86,7 @@ jobs:
         run: npm run package
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-windows
           path: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -69,16 +69,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: release-*
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.bump-version.outputs.version }}
           generate_release_notes: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,18 +14,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup SSH for private submodule
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: actions/checkout@v6
         with:
-          ssh-private-key: ${{ secrets.CC_MASCOT_PRIVATE_DEPLOY_KEY }}
-
-      - name: Initialize private submodule
-        run: git submodule update --init
+          ssh-key: ${{ secrets.CC_MASCOT_PRIVATE_DEPLOY_KEY }}
+          submodules: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"
@@ -42,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"
@@ -62,10 +57,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- GitHub Actionsで使用しているActionの参照バージョンを更新
- private submodule取得をwebfactory/ssh-agentからactions/checkoutのssh-key + submodules指定へ変更
- release / deploy / validate / pages の各workflowを整理

## :camera: なぜやったのか（背景・目的）

GitHub ActionsのNode 20非推奨警告に対応し、CI/CDで使用するActionを更新するため。

## :bookmark: 関連URL


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)