### PR TITLE
Gemini CLI v0.39以降のJSONLログ形式に対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@
 - chokidar (ログファイル監視)
 - Claude Code: `~/.claude/projects/**/*.jsonl`（JSONL形式、差分読み取り）
 - Codex: `~/.codex/sessions/**/*.jsonl`（JSONL形式、差分読み取り）
-- Gemini CLI: `~/.gemini/tmp/*/chats/*.json`（JSON形式、メッセージID重複排除）
+- Gemini CLI: `~/.gemini/tmp/*/chats/*.jsonl`（JSONL形式、差分読み取り）
 
 **データ永続化:**
 
@@ -55,11 +55,11 @@
 ┌──────────────────────┐   ┌──────────────────────┐   ┌──────────────────────┐
 │   Claude Code CLI    │   │        Codex         │   │     Gemini CLI        │
 └──────────┬───────────┘   └──────────┬───────────┘   └──────────┬────────────┘
-           │ ログ出力 (.jsonl)          │ ログ出力 (.jsonl)         │ ログ出力 (.json)
+           │ ログ出力 (.jsonl)          │ ログ出力 (.jsonl)         │ ログ出力 (.jsonl)
            ↓                          ↓                          ↓
 ┌──────────────────────┐   ┌──────────────────────┐   ┌──────────────────────────┐
 │  ~/.claude/projects/ │   │ ~/.codex/sessions/   │   │  ~/.gemini/tmp/*/chats/  │
-│  └─ **/*.jsonl       │   │ └─ **/*.jsonl         │   │  └─ session-*.json        │
+│  └─ **/*.jsonl       │   │ └─ **/*.jsonl         │   │  └─ session-*.jsonl       │
 └──────────┬───────────┘   └──────────┬───────────┘   └──────────┬───────────────┘
            │                          │                          │
            └──────────────────────────┼──────────────────────────┘
@@ -67,15 +67,15 @@
                                       ↓
 ┌─────────────────────────────────────────────────────┐
 │  Electron Main Process                              │
-│  ├─ logMonitor.ts (ファイル監視・mode分岐)            │
+│  ├─ logMonitor.ts (ファイル監視)                      │
 │  ├─ adapters/ (HarnessAdapter)                      │
 │  │   ├─ claudeCodeAdapter.ts (JSONL・差分読み取り)   │
 │  │   ├─ codexAdapter.ts (JSONL・差分読み取り)        │
-│  │   └─ geminiCliAdapter.ts (JSON・ID重複排除)       │
+│  │   └─ geminiCliAdapter.ts (JSONL・差分読み取り)    │
 │  ├─ activeSessionMonitor.ts (セッションフィルタ)      │
 │  ├─ parsers/claudeCodeParser.ts (JSONL解析)         │
 │  ├─ parsers/codexParser.ts (JSONL解析)              │
-│  ├─ parsers/geminiCliParser.ts (JSON解析)           │
+│  ├─ parsers/geminiCliParser.ts (JSONL解析)          │
 │  ├─ textFilter.ts (Markdown除去)                    │
 │  ├─ ruleBasedEmotionClassifier.ts (感情判定)        │
 │  └─ IPC送信 ('speak' イベント)                       │
@@ -153,14 +153,15 @@
 設計方針:
 
 - `HarnessAdapter` インターフェース経由で複数ハーネスのログを並列監視
-- アダプターが `mode: "jsonl" | "json"` を宣言し、logMonitor が処理方式を切り替える
+- 全てのアダプターが JSONL 形式（追記型）であることを前提とし、差分読み取り（ファイル位置ベース）でログを処理する
 - デバウンス処理（100ms）で過剰な処理を防ぐ
 - インスタンスごとに独立した状態（複数モニター並列動作をサポート）
 
 **HarnessAdapter インターフェース** (`electron/adapters/harnessAdapter.ts`):
 
-- `JsonlHarnessAdapter` (mode: "jsonl"): 差分読み取り（ファイル位置ベース）、`parseLine()` を使用
-- `JsonHarnessAdapter` (mode: "json"): ファイル全体読み取り、`parseFile()` でメッセージIDによる重複排除
+- 追記型ログの解析に特化した単一のインターフェース
+- `parseLine()`: ログの1行を解析してメッセージを抽出
+- `shouldProcessFile()`: セッションIDによるフィルタリング判定
 
 **各アダプターの監視対象:**
 
@@ -168,17 +169,18 @@
 | ---------------------- | ------------------------------- | --------------------- |
 | `claudeCodeAdapter.ts` | `~/.claude/projects/**/*.jsonl` | JSONL（差分読み取り） |
 | `codexAdapter.ts`      | `~/.codex/sessions/**/*.jsonl`  | JSONL（差分読み取り） |
-| `geminiCliAdapter.ts`  | `~/.gemini/tmp/*/chats/*.json`  | JSON（ID重複排除）    |
+| `geminiCliAdapter.ts`  | `~/.gemini/tmp/*/chats/*.jsonl` | JSONL（差分読み取り） |
 
-データフロー（共通部分）:
+データフロー:
 
 ```
 ファイル変更検出 (chokidar)
   ↓
 セッションフィルタ判定 (adapter.shouldProcessFile)
   ↓
-[mode: "jsonl"] 差分読み取り → adapter.parseLine(line)
-[mode: "json"]  全体読み取り → adapter.parseFile(filePath)
+差分読み取り (readline)
+  ↓
+1行パース (adapter.parseLine)
   ↓
 テキストフィルタリング (textFilter.cleanTextForSpeech)
   ↓
@@ -215,6 +217,7 @@
 
 - `type === "gemini"` の行のみ処理
 - `content` フィールドは文字列型（将来の配列形式にも対応）
+- メッセージIDによる重複排除を行い、思考プロセス（`thoughts`）のみの空メッセージによる発話ブロックを回避
 
 **electron/services/ruleBasedEmotionClassifier.ts**
 
@@ -475,7 +478,7 @@ Claude Code / Codex / Gemini CLI の並列実行時に特定セッションの�
 - ファイルパスのベースネーム（拡張子除去）がセッションIDと一致 → 通過
 - 親ディレクトリ名がセッションIDと一致 → 通過
 - Codexは `rollout-...-<sessionId>.jsonl` の末尾セッションID一致でも通過
-- Gemini CLIはJSON内の `sessionId` が一致する場合に通過
+- Gemini CLIはJSONL内の `sessionId` が一致する場合に通過
 - フィルタ外のファイルは `skipFileChanges()` でファイル位置のみ進めてスキップ（フィルタ解除後に過去の発話が再生されるのを防ぐ）
 
 操作方法:
@@ -623,9 +626,7 @@ cc-mascot/
 ### ファイル監視
 
 - デバウンス100ms（過剰な処理防止）
-- Claude Code: depth=1、差分読み取り（全体読み込み回避）
-- Codex: depth=4、差分読み取り（`sessions/YYYY/MM/DD/*.jsonl` に対応）
-- Gemini CLI: depth=2、メッセージID重複排除（追記ではなく全体書き換え形式のため）
+- 追記型ログ（JSONL）を差分読み取りすることで、ファイル全体の再読み込みを回避
 
 ### VRM読み込み
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,6 @@ https://github.com/kazakago/cc-mascot/releases
 - テキストから感情を自動判定
 - 音声合成してキャラクターが発話
 
-**監視対象ログ:**
-
-| エージェント | ログパス                        | 形式  |
-| ------------ | ------------------------------- | ----- |
-| Claude Code  | `~/.claude/projects/**/*.jsonl` | JSONL |
-| Codex        | `~/.codex/sessions/**/*.jsonl`  | JSONL |
-| Gemini CLI   | `~/.gemini/tmp/*/chats/*.json`  | JSON  |
-
 ## 基本操作
 
 ### キャラクターの操作
@@ -171,8 +163,8 @@ CC Mascotの設定画面からもフィルタの状態確認・解除が可能�
 
 ```
 Claude Code                  Codex                         Gemini CLI
-    ↓ JSONLログ出力              ↓ JSONLログ出力                 ↓ JSONログ出力
-~/.claude/projects/**/*.jsonl  ~/.codex/sessions/**/*.jsonl  ~/.gemini/tmp/*/chats/*.json
+    ↓ JSONLログ出力              ↓ JSONLログ出力                 ↓ JSONLログ出力
+~/.claude/projects/**/*.jsonl  ~/.codex/sessions/**/*.jsonl  ~/.gemini/tmp/*/chats/*.jsonl
     ↓ chokidar監視（HarnessAdapter経由で各形式に対応）
 Electron Main Process
     ↓ ログパース & 感情判定

--- a/electron/adapters/claudeCodeAdapter.ts
+++ b/electron/adapters/claudeCodeAdapter.ts
@@ -13,8 +13,6 @@ export function createClaudeCodeAdapter(): HarnessAdapter {
   const claudeProjectsDir = path.join(claudeConfigDir, "projects");
 
   return {
-    mode: "jsonl" as const,
-
     getWatchPaths() {
       return [claudeProjectsDir];
     },

--- a/electron/adapters/codexAdapter.ts
+++ b/electron/adapters/codexAdapter.ts
@@ -6,10 +6,10 @@
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
-import type { JsonlHarnessAdapter, SpeakMessage } from "./harnessAdapter";
+import type { HarnessAdapter, SpeakMessage } from "./harnessAdapter";
 import { parseCodexLog } from "../parsers/codexParser";
 
-export function createCodexAdapter(): JsonlHarnessAdapter {
+export function createCodexAdapter(): HarnessAdapter {
   const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
   const codexSessionsDir = path.join(codexHome, "sessions");
   const subagentLogFiles = new Map<string, boolean>();
@@ -37,8 +37,6 @@ export function createCodexAdapter(): JsonlHarnessAdapter {
   }
 
   return {
-    mode: "jsonl",
-
     getWatchPaths() {
       return [codexSessionsDir];
     },

--- a/electron/adapters/geminiCliAdapter.test.ts
+++ b/electron/adapters/geminiCliAdapter.test.ts
@@ -8,7 +8,7 @@ vi.mock("fs", () => ({
 
 import { createGeminiCliAdapter } from "./geminiCliAdapter";
 
-describe("createGeminiCliAdapter", () => {
+describe("createGeminiCliAdapter (JSONL)", () => {
   const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
 
   beforeEach(() => {
@@ -35,86 +35,56 @@ describe("createGeminiCliAdapter", () => {
     });
   });
 
-  it("json以外のファイルを除外する", () => {
+  it("jsonl以外のファイルを除外する", () => {
     const adapter = createGeminiCliAdapter();
     const ignored = adapter.getWatchOptions().ignored as (filePath: string, stats?: { isFile(): boolean }) => boolean;
 
-    expect(ignored("/tmp/session.json", { isFile: () => true })).toBe(false);
-    expect(ignored("/tmp/session.jsonl", { isFile: () => true })).toBe(true);
+    expect(ignored("/tmp/session.jsonl", { isFile: () => true })).toBe(false);
+    expect(ignored("/tmp/session.json", { isFile: () => true })).toBe(true);
     expect(ignored("/tmp/chats", { isFile: () => false })).toBe(false);
   });
 
-  it("parseFileで未処理のGeminiメッセージだけを返す", () => {
+  it("parseLineで未処理のGeminiメッセージだけを返す", () => {
     const adapter = createGeminiCliAdapter();
-    const filePath = "/tmp/.gemini/tmp/project/chats/session.json";
+    const filePath = "/tmp/session.jsonl";
 
-    (fsMod.readFileSync as any).mockReturnValue(
-      JSON.stringify({
-        sessionId: "session-123",
-        messages: [
-          { id: "user-1", type: "user", content: [{ text: "質問" }] },
-          { id: "gemini-1", type: "gemini", content: "最初の回答です。" },
-          { id: "gemini-2", type: "gemini", content: "次の回答です。" },
-        ],
-      }),
-    );
+    const line1 = JSON.stringify({ id: "gemini-1", type: "gemini", content: "最初の回答です。" });
+    const line2 = JSON.stringify({ id: "gemini-2", type: "gemini", content: "次の回答です。" });
 
-    const first = adapter.parseFile(filePath);
-    const second = adapter.parseFile(filePath);
+    const first = adapter.parseLine(line1, filePath);
+    const second = adapter.parseLine(line1, filePath); // 同じID
+    const third = adapter.parseLine(line2, filePath);
 
-    expect(first.map((message) => message.text)).toEqual(["最初の回答です。", "次の回答です。"]);
+    expect(first.map((m) => m.text)).toEqual(["最初の回答です。"]);
     expect(second).toEqual([]);
+    expect(third.map((m) => m.text)).toEqual(["次の回答です。"]);
   });
 
-  it("同じメッセージIDでも別ファイルなら処理対象にする", () => {
+  it("空メッセージではIDを消費しない", () => {
     const adapter = createGeminiCliAdapter();
+    const filePath = "/tmp/session.jsonl";
 
-    (fsMod.readFileSync as any).mockReturnValue(
-      JSON.stringify({
-        sessionId: "session-123",
-        messages: [{ id: "gemini-1", type: "gemini", content: "回答です。" }],
-      }),
-    );
+    const lineEmpty = JSON.stringify({ id: "gemini-1", type: "gemini", content: "", thoughts: [{}] });
+    const lineFull = JSON.stringify({ id: "gemini-1", type: "gemini", content: "本番の回答です。" });
 
-    expect(adapter.parseFile("/tmp/project-a/chats/session.json")).toHaveLength(1);
-    expect(adapter.parseFile("/tmp/project-b/chats/session.json")).toHaveLength(1);
-  });
+    const first = adapter.parseLine(lineEmpty, filePath);
+    const second = adapter.parseLine(lineFull, filePath); // 同じIDだが、前回が空だったので処理されるべき
 
-  it("IDがないメッセージはスキップする", () => {
-    const adapter = createGeminiCliAdapter();
-
-    (fsMod.readFileSync as any).mockReturnValue(
-      JSON.stringify({
-        sessionId: "session-123",
-        messages: [{ type: "gemini", content: "IDなしの回答です。" }],
-      }),
-    );
-
-    expect(adapter.parseFile("/tmp/session.json")).toEqual([]);
+    expect(first).toEqual([]);
+    expect(second.map((m) => m.text)).toEqual(["本番の回答です。"]);
   });
 
   it("セッションIDでフィルタ判定する", () => {
     const adapter = createGeminiCliAdapter();
+    const filePath = "/tmp/session.jsonl";
 
     (fsMod.readFileSync as any).mockReturnValue(
-      JSON.stringify({
-        sessionId: "session-123",
-        messages: [],
-      }),
+      JSON.stringify({ sessionId: "session-123" }) +
+        "\n" +
+        JSON.stringify({ id: "user-1", type: "user", content: [{ text: "hi" }] }),
     );
 
-    expect(adapter.shouldProcessFile("/tmp/session.json", "session-123")).toBe(true);
-    expect(adapter.shouldProcessFile("/tmp/session.json", "other-session")).toBe(false);
-  });
-
-  it("セッションファイルを読めない場合は空配列とfalseを返す", () => {
-    const adapter = createGeminiCliAdapter();
-
-    (fsMod.readFileSync as any).mockImplementation(() => {
-      throw new Error("File not found");
-    });
-
-    expect(adapter.parseFile("/tmp/missing.json")).toEqual([]);
-    expect(adapter.shouldProcessFile("/tmp/missing.json", "session-123")).toBe(false);
+    expect(adapter.shouldProcessFile(filePath, "session-123")).toBe(true);
+    expect(adapter.shouldProcessFile(filePath, "other-session")).toBe(false);
   });
 });

--- a/electron/adapters/geminiCliAdapter.ts
+++ b/electron/adapters/geminiCliAdapter.ts
@@ -1,41 +1,46 @@
 /**
  * Gemini CLI ハーネスアダプター
- * ~/.gemini/tmp/<project_name>/chats/*.json を監視し、Gemini CLI の JSON ログ形式を解析する
+ * ~/.gemini/tmp/<project_name>/chats/*.jsonl を監視し、Gemini CLI の JSONL ログ形式を解析する
  *
- * ログパス: ~/.gemini/tmp/<project_name>/chats/session-YYYY-MM-DDTHH-mm-<short_id>.json
- * ファイル全体が更新のたびに書き換えられる形式のため、メッセージIDで重複排除する
+ * ログパス: ~/.gemini/tmp/<project_name>/chats/session-YYYY-MM-DDTHH-mm-<short_id>.jsonl
  *
  * GEMINI_CLI_HOME 環境変数が設定されている場合、$GEMINI_CLI_HOME/.gemini/tmp を使用する
  * （未設定時は ~/.gemini/tmp）
  */
 
+import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import type { JsonHarnessAdapter, SpeakMessage } from "./harnessAdapter";
-import { parseGeminiMessage, parseGeminiSessionFile } from "../parsers/geminiCliParser";
+import type { HarnessAdapter, SpeakMessage } from "./harnessAdapter";
+import { parseGeminiLogLine } from "../parsers/geminiCliParser";
 
-export function createGeminiCliAdapter(): JsonHarnessAdapter {
+function getGeminiTmpDir(): string {
   const geminiBase = process.env.GEMINI_CLI_HOME
     ? path.join(process.env.GEMINI_CLI_HOME, ".gemini")
     : path.join(os.homedir(), ".gemini");
-  const geminiTmpDir = path.join(geminiBase, "tmp");
+  return path.join(geminiBase, "tmp");
+}
 
-  // ファイルパス → 処理済みメッセージIDのセット
+/**
+ * Gemini CLI用のアダプター（JSONL形式）
+ */
+export function createGeminiCliAdapter(): HarnessAdapter {
+  const geminiTmpDir = getGeminiTmpDir();
+
+  // ファイルパス → 処理済みメッセージIDのセット（追記型でも更新があるためIDで重複排除が必要）
   const processedIds = new Map<string, Set<string>>();
 
   return {
-    mode: "json",
-
     getWatchPaths() {
       return [geminiTmpDir];
     },
 
     getWatchOptions() {
       return {
-        // <project_name>/chats/*.json の構造なので depth=2
+        // <project_name>/chats/*.jsonl の構造なので depth=2
         depth: 2,
         ignored: (filePath: string, stats?: { isFile(): boolean }) =>
-          stats?.isFile() === true && !filePath.endsWith(".json"),
+          stats?.isFile() === true && !filePath.endsWith(".jsonl"),
         awaitWriteFinish: {
           stabilityThreshold: 100,
           pollInterval: 50,
@@ -43,36 +48,48 @@ export function createGeminiCliAdapter(): JsonHarnessAdapter {
       };
     },
 
-    parseFile(filePath: string): SpeakMessage[] {
-      const result = parseGeminiSessionFile(filePath);
-      if (!result) return [];
+    parseLine(line: string, logFilePath?: string): SpeakMessage[] {
+      try {
+        const data = JSON.parse(line);
+        const id = data.id;
 
-      if (!processedIds.has(filePath)) {
-        processedIds.set(filePath, new Set());
+        // メッセージではない行（メタデータなど）や、既に処理済みのIDはスキップ
+        if (!id || (logFilePath && processedIds.get(logFilePath)?.has(id))) {
+          return [];
+        }
+
+        const parsed = parseGeminiLogLine(line);
+        if (parsed.length > 0 && logFilePath) {
+          if (!processedIds.has(logFilePath)) {
+            processedIds.set(logFilePath, new Set());
+          }
+          processedIds.get(logFilePath)!.add(id);
+        }
+
+        return parsed;
+      } catch {
+        return [];
       }
-      const seen = processedIds.get(filePath)!;
-
-      const newMessages: SpeakMessage[] = [];
-
-      for (const message of result.messages) {
-        const id = message.id;
-        if (!id || seen.has(id)) continue;
-        seen.add(id);
-
-        const parsed = parseGeminiMessage(message);
-        newMessages.push(...parsed);
-      }
-
-      return newMessages;
     },
 
     shouldProcessFile(filePath: string, activeSessionId: string): boolean {
-      // ファイルを読み込んでセッションIDと照合する
-      // 読み込みコストを避けるため、processedIds に登録済みであればキャッシュから判定
-      // （parseFile を一度でも呼ぶと内部状態が構築される）
-      const result = parseGeminiSessionFile(filePath);
-      if (!result?.sessionId) return false;
-      return result.sessionId === activeSessionId;
+      try {
+        // ファイルの最初の数行から sessionId を探す（通常は1行目にある）
+        const content = fs.readFileSync(filePath, "utf8");
+        const lines = content.split("\n");
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          const data = JSON.parse(line);
+          if (data.sessionId) {
+            return data.sessionId === activeSessionId;
+          }
+          // メッセージ行が先に来た場合は諦める
+          break;
+        }
+      } catch {
+        // ignore
+      }
+      return false;
     },
   };
 }

--- a/electron/adapters/harnessAdapter.ts
+++ b/electron/adapters/harnessAdapter.ts
@@ -13,7 +13,12 @@ export interface SpeakMessage {
   emotion?: "neutral" | "happy" | "angry" | "sad" | "relaxed" | "surprised";
 }
 
-interface BaseHarnessAdapter {
+/**
+ * ログファイルを扱うアダプター
+ * 全てのアダプターは現在 JSONL 形式（追記型）を前提とし、
+ * 差分読み取り（ファイル位置ベース）でログを処理する
+ */
+export interface HarnessAdapter {
   /**
    * 監視対象のディレクトリ・ファイルパスのリスト
    */
@@ -25,41 +30,16 @@ interface BaseHarnessAdapter {
   getWatchOptions(): WatchOptions;
 
   /**
+   * ログの1行を解析してSpeakMessageの配列に変換する
+   * @param line - ログファイルの1行
+   * @param logFilePath - ログファイルのパス（文脈参照が必要な実装で使用）
+   */
+  parseLine(line: string, logFilePath?: string): SpeakMessage[];
+
+  /**
    * セッションIDに基づいてファイルを処理すべきか判定する
    * @param filePath - 判定対象のファイルパス
    * @param activeSessionId - 現在アクティブなセッションID
    */
   shouldProcessFile(filePath: string, activeSessionId: string): boolean;
 }
-
-/**
- * JSONL形式（追記型）のログファイルを扱うアダプター
- * 差分読み取り（ファイル位置ベース）でログを処理する
- */
-export interface JsonlHarnessAdapter extends BaseHarnessAdapter {
-  mode: "jsonl";
-
-  /**
-   * ログの1行を解析してSpeakMessageの配列に変換する
-   * @param line - ログファイルの1行
-   * @param logFilePath - ログファイルのパス（文脈参照が必要な実装で使用）
-   */
-  parseLine(line: string, logFilePath?: string): SpeakMessage[];
-}
-
-/**
- * JSON形式（全体書き換え型）のログファイルを扱うアダプター
- * ファイル全体を読み取り、メッセージIDで重複排除してログを処理する
- */
-export interface JsonHarnessAdapter extends BaseHarnessAdapter {
-  mode: "json";
-
-  /**
-   * ファイル全体を読み取り、未処理のメッセージのみ返す
-   * アダプター内部でメッセージIDを追跡し重複排除する
-   * @param filePath - ログファイルのパス
-   */
-  parseFile(filePath: string): SpeakMessage[];
-}
-
-export type HarnessAdapter = JsonlHarnessAdapter | JsonHarnessAdapter;

--- a/electron/logMonitor.test.ts
+++ b/electron/logMonitor.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fsMod from "fs";
 import * as readlineMod from "readline";
 import * as chokidarMod from "chokidar";
-import type { JsonlHarnessAdapter, JsonHarnessAdapter } from "./adapters/harnessAdapter";
+import type { HarnessAdapter } from "./adapters/harnessAdapter";
 
 // モックを設定
 vi.mock("fs", () => ({
@@ -36,9 +36,8 @@ vi.mock("./services/ruleBasedEmotionClassifier", () => ({
 import { createLogMonitor } from "./logMonitor";
 
 /** テスト用 JSONL アダプターを作成する */
-function createMockJsonlAdapter(overrides: Partial<JsonlHarnessAdapter> = {}): JsonlHarnessAdapter {
+function createMockJsonlAdapter(overrides: Partial<HarnessAdapter> = {}): HarnessAdapter {
   return {
-    mode: "jsonl",
     getWatchPaths: () => ["/mock/watch/path"],
     getWatchOptions: () => ({
       ignored: (filePath: string, stats?: { isFile(): boolean }) =>
@@ -47,23 +46,6 @@ function createMockJsonlAdapter(overrides: Partial<JsonlHarnessAdapter> = {}): J
       depth: 1,
     }),
     parseLine: vi.fn().mockReturnValue([]),
-    shouldProcessFile: vi.fn().mockReturnValue(true),
-    ...overrides,
-  };
-}
-
-/** テスト用 JSON アダプターを作成する */
-function createMockJsonAdapter(overrides: Partial<JsonHarnessAdapter> = {}): JsonHarnessAdapter {
-  return {
-    mode: "json",
-    getWatchPaths: () => ["/mock/watch/path"],
-    getWatchOptions: () => ({
-      ignored: (filePath: string, stats?: { isFile(): boolean }) =>
-        stats?.isFile() === true && !filePath.endsWith(".json"),
-      awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
-      depth: 2,
-    }),
-    parseFile: vi.fn().mockReturnValue([]),
     shouldProcessFile: vi.fn().mockReturnValue(true),
     ...overrides,
   };
@@ -728,93 +710,6 @@ describe("logMonitor", () => {
 
       // 600-500=100バイト分のみ読み取られる
       expect(fsMod.createReadStream).toHaveBeenCalledWith(filePath, expect.objectContaining({ start: 500, end: 599 }));
-    });
-  });
-
-  describe("JSON モード（parseFile）", () => {
-    it("addイベントでparseFileを呼び出して既存メッセージIDを登録する", () => {
-      const mockWatcher = {
-        on: vi.fn((event, callback) => {
-          if (event === "add") callback("/test/session.json");
-        }),
-        close: vi.fn(),
-      };
-      (chokidarMod.watch as any).mockReturnValue(mockWatcher as any);
-
-      const adapter = createMockJsonAdapter();
-      createLogMonitor(mockBroadcast, adapter);
-
-      expect(adapter.parseFile).toHaveBeenCalledWith("/test/session.json");
-      // addイベントではbroadcastしない
-      expect(mockBroadcast).not.toHaveBeenCalled();
-    });
-
-    it("changeイベントでparseFileの結果をブロードキャストする", async () => {
-      vi.spyOn(console, "log").mockImplementation(() => {});
-      const { cleanTextForSpeech } = await import("./filters/textFilter");
-      (cleanTextForSpeech as any).mockReturnValue("Geminiの応答テキスト。");
-
-      let addCallback: ((filePath: string) => void) | null = null;
-      let changeCallback: ((filePath: string) => void) | null = null;
-      const mockWatcher = {
-        on: vi.fn((event: string, callback: (arg?: any) => void) => {
-          if (event === "add") addCallback = callback as (filePath: string) => void;
-          if (event === "change") changeCallback = callback as (filePath: string) => void;
-        }),
-        close: vi.fn(),
-      };
-      (chokidarMod.watch as any).mockReturnValue(mockWatcher as any);
-
-      const adapter = createMockJsonAdapter({
-        parseFile: vi.fn().mockReturnValue([{ type: "speak", text: "Geminiの応答テキスト。", emotion: "neutral" }]),
-      });
-
-      createLogMonitor(mockBroadcast, adapter);
-      addCallback!("/test/session.json");
-
-      changeCallback!("/test/session.json");
-
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(adapter.parseFile).toHaveBeenCalledWith("/test/session.json");
-      expect(mockBroadcast).toHaveBeenCalledWith(
-        JSON.stringify({ type: "speak", text: "Geminiの応答テキスト。", emotion: "neutral" }),
-      );
-    });
-
-    it("アクティブセッションIDが不一致の場合はparseFileを呼ばない", async () => {
-      let addCallback: ((filePath: string) => void) | null = null;
-      let changeCallback: ((filePath: string) => void) | null = null;
-      const mockWatcher = {
-        on: vi.fn((event: string, callback: (arg?: any) => void) => {
-          if (event === "add") addCallback = callback as (filePath: string) => void;
-          if (event === "change") changeCallback = callback as (filePath: string) => void;
-        }),
-        close: vi.fn(),
-      };
-      (chokidarMod.watch as any).mockReturnValue(mockWatcher as any);
-
-      const adapter = createMockJsonAdapter({
-        shouldProcessFile: vi.fn().mockReturnValue(false),
-      });
-
-      createLogMonitor(mockBroadcast, adapter, () => "some-session-id");
-      addCallback!("/test/session.json");
-
-      // parseFile は add 時に1回呼ばれているはず
-      const callCountAfterAdd = (adapter.parseFile as any).mock.calls.length;
-
-      changeCallback!("/test/session.json");
-
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      // change では parseFile を呼ばない
-      expect((adapter.parseFile as any).mock.calls.length).toBe(callCountAfterAdd);
-      expect(mockBroadcast).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/logMonitor.ts
+++ b/electron/logMonitor.ts
@@ -1,7 +1,7 @@
 import * as chokidar from "chokidar";
 import * as fs from "fs";
 import * as readline from "readline";
-import type { HarnessAdapter, JsonlHarnessAdapter, SpeakMessage } from "./adapters/harnessAdapter";
+import type { HarnessAdapter, SpeakMessage } from "./adapters/harnessAdapter";
 import { cleanTextForSpeech, splitIntoSentences } from "./filters/textFilter";
 import { RuleBasedEmotionClassifier } from "./services/ruleBasedEmotionClassifier";
 
@@ -16,8 +16,8 @@ type BroadcastFn = (message: string) => void;
  * Create a log monitor that watches harness session logs via the given adapter.
  * Each call creates an independent monitor with its own file-position and debounce state.
  *
- * - mode: "jsonl" → 差分読み取り（ファイル位置ベース）、parseLine を使用
- * - mode: "json"  → ファイル全体読み取り、parseFile を使用（メッセージIDで重複排除）
+ * 全てのアダプターが JSONL 形式（追記型）であることを前提とし、
+ * 差分読み取り（ファイル位置ベース）でログを処理する。
  *
  * @param broadcast - Callback function to send messages to the renderer process
  * @param adapter - Harness adapter that provides watch paths, options, and log parsing
@@ -29,11 +29,9 @@ export function createLogMonitor(
   adapter: HarnessAdapter,
   getActiveSessionId?: () => string | null,
 ) {
-  // JSONL モード用: ファイル位置・デバウンス状態（インスタンスごとに独立）
+  // ファイル位置・デバウンス状態（インスタンスごとに独立）
   const filePositions = new Map<string, number>();
   const lastProcessed = new Map<string, number>();
-
-  // --- JSONL モード用ヘルパー ---
 
   function initializeFilePosition(filePath: string) {
     try {
@@ -53,7 +51,7 @@ export function createLogMonitor(
     }
   }
 
-  async function processJsonlFile(filePath: string) {
+  async function processFile(filePath: string) {
     const now = Date.now();
     const lastTime = lastProcessed.get(filePath) || 0;
     if (now - lastTime < DEBOUNCE_MS) return;
@@ -74,31 +72,11 @@ export function createLogMonitor(
       const newContent = await readNewLines(filePath, startPosition, currentSize);
       filePositions.set(filePath, currentSize);
 
-      const jsonlAdapter = adapter as JsonlHarnessAdapter;
       for (const line of newContent) {
-        const messages = jsonlAdapter.parseLine(line, filePath);
+        const messages = adapter.parseLine(line, filePath);
         for (const message of messages) {
           broadcastMessages(message);
         }
-      }
-    } catch (err) {
-      console.error(`[LogMonitor] Error processing ${filePath}:`, err);
-    }
-  }
-
-  // --- JSON モード用ヘルパー ---
-
-  async function processJsonFile(filePath: string) {
-    const now = Date.now();
-    const lastTime = lastProcessed.get(filePath) || 0;
-    if (now - lastTime < DEBOUNCE_MS) return;
-    lastProcessed.set(filePath, now);
-
-    try {
-      if (adapter.mode !== "json") return;
-      const messages = adapter.parseFile(filePath);
-      for (const message of messages) {
-        broadcastMessages(message);
       }
     } catch (err) {
       console.error(`[LogMonitor] Error processing ${filePath}:`, err);
@@ -133,33 +111,20 @@ export function createLogMonitor(
   const watcher = chokidar.watch(adapter.getWatchPaths(), adapter.getWatchOptions());
 
   watcher.on("add", (filePath: string) => {
-    if (adapter.mode === "jsonl") {
-      // JSONL: ファイル位置を現在の末尾に初期化（既存ログの再生を防ぐ）
-      initializeFilePosition(filePath);
-    } else {
-      // JSON: 初回 parseFile で既存メッセージIDを登録（再生を防ぐ）
-      adapter.parseFile(filePath);
-    }
+    // ファイル位置を現在の末尾に初期化（既存ログの再生を防ぐ）
+    initializeFilePosition(filePath);
   });
 
   watcher.on("change", (filePath: string) => {
     const activeSessionId = getActiveSessionId?.() ?? null;
     if (activeSessionId && !adapter.shouldProcessFile(filePath, activeSessionId)) {
-      if (adapter.mode === "jsonl") {
-        // JSONL: フィルタ解除後に過去ログが再生されないよう位置を進める
-        skipFileChanges(filePath);
-      }
-      // JSON: parseFile を呼ばないだけでよい（IDは未登録のまま残るが、
-      //        現状 Gemini CLI にはセッション固定の手段がないため許容）
+      // フィルタ解除後に過去ログが再生されないよう位置を進める
+      skipFileChanges(filePath);
       return;
     }
 
     console.log(`[LogMonitor] File changes detected: ${filePath}`);
-    if (adapter.mode === "jsonl") {
-      processJsonlFile(filePath);
-    } else {
-      processJsonFile(filePath);
-    }
+    processFile(filePath);
   });
 
   watcher.on("error", (error: unknown) => {

--- a/electron/parsers/geminiCliParser.test.ts
+++ b/electron/parsers/geminiCliParser.test.ts
@@ -1,12 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, vi } from "vitest";
-import * as fsMod from "fs";
+import { describe, it, expect } from "vitest";
 
-vi.mock("fs", () => ({
-  readFileSync: vi.fn(),
-}));
-
-import { parseGeminiMessage, parseGeminiSessionFile } from "./geminiCliParser";
+import { parseGeminiLogLine, parseGeminiMessage } from "./geminiCliParser";
 
 describe("parseGeminiMessage", () => {
   describe("アシスタント応答の抽出", () => {
@@ -78,52 +73,54 @@ describe("parseGeminiMessage", () => {
   });
 });
 
-describe("parseGeminiSessionFile", () => {
-  it("正常なセッションJSONからsessionIdとmessagesを取得する", () => {
-    (fsMod.readFileSync as any).mockReturnValue(
-      JSON.stringify({
-        sessionId: "ses_abc123",
-        messages: [
-          { id: "m1", type: "user", content: [{ text: "質問" }] },
-          { id: "m2", type: "gemini", content: "回答テキスト" },
-        ],
-      }),
-    );
-
-    const result = parseGeminiSessionFile("/fake/path/session.json");
-
-    expect(result).not.toBeNull();
-    expect(result?.sessionId).toBe("ses_abc123");
-    expect(result?.messages).toHaveLength(2);
-  });
-
-  it("ファイル読み込みエラーの場合は null を返す", () => {
-    (fsMod.readFileSync as any).mockImplementation(() => {
-      throw new Error("File not found");
+describe("parseGeminiLogLine", () => {
+  it("JSONLのgemini行からテキストを抽出する", () => {
+    const line = JSON.stringify({
+      id: "msg2",
+      timestamp: "2026-04-26T23:40:11.674Z",
+      type: "gemini",
+      content: "回答テキスト",
+      thoughts: [{ subject: "Thinking" }],
     });
 
-    const result = parseGeminiSessionFile("/nonexistent/path.json");
-    expect(result).toBeNull();
+    const result = parseGeminiLogLine(line);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "speak",
+      text: "回答テキスト",
+    });
   });
 
-  it("不正な JSON の場合は null を返す", () => {
-    (fsMod.readFileSync as any).mockReturnValue("not-json");
+  it("sessionIdを含むメタデータ行は無視する", () => {
+    const line = JSON.stringify({
+      sessionId: "ses_abc123",
+      projectHash: "project-hash",
+      kind: "main",
+    });
 
-    const result = parseGeminiSessionFile("/fake/path.json");
-    expect(result).toBeNull();
+    expect(parseGeminiLogLine(line)).toEqual([]);
   });
 
-  it("messagesフィールドがない場合は空配列を返す", () => {
-    (fsMod.readFileSync as any).mockReturnValue(JSON.stringify({ sessionId: "ses_xyz" }));
+  it("$set更新行は無視する", () => {
+    const line = JSON.stringify({
+      $set: { lastUpdated: "2026-04-26T23:40:11.674Z" },
+    });
 
-    const result = parseGeminiSessionFile("/fake/path.json");
-    expect(result?.messages).toEqual([]);
+    expect(parseGeminiLogLine(line)).toEqual([]);
   });
 
-  it("sessionIdフィールドがない場合は null を返す", () => {
-    (fsMod.readFileSync as any).mockReturnValue(JSON.stringify({ messages: [] }));
+  it("user行は無視する", () => {
+    const line = JSON.stringify({
+      id: "msg1",
+      type: "user",
+      content: [{ text: "質問" }],
+    });
 
-    const result = parseGeminiSessionFile("/fake/path.json");
-    expect(result?.sessionId).toBeNull();
+    expect(parseGeminiLogLine(line)).toEqual([]);
+  });
+
+  it("不正なJSONは空配列を返す", () => {
+    expect(parseGeminiLogLine("not-json")).toEqual([]);
   });
 });

--- a/electron/parsers/geminiCliParser.ts
+++ b/electron/parsers/geminiCliParser.ts
@@ -1,24 +1,13 @@
 /**
- * Gemini CLI JSONログパーサー
+ * Gemini CLI JSONLログパーサー
  * Gemini CLIのセッションログを解析し、アシスタントメッセージを抽出する
  *
- * 実際のログフォーマット（~/.gemini/tmp/<project_name>/chats/session-*.json）:
- * {
- *   "sessionId": "...",
- *   "projectHash": "...",
- *   "startTime": "...",
- *   "lastUpdated": "...",
- *   "messages": [
- *     {"id": "...", "type": "user", "content": [{"text": "..."}]},
- *     {"id": "...", "type": "gemini", "content": "応答テキスト文字列", ...},
- *     ...
- *   ]
- * }
- *
- * 注意: type === "gemini" の content は文字列（string）であり、配列ではない
+ * 実際のログフォーマット（~/.gemini/tmp/<project_name>/chats/session-*.jsonl）:
+ * {"sessionId": "...", "startTime": "...", ...}
+ * {"id": "...", "type": "user", "content": [{"text": "..."}]}
+ * {"id": "...", "type": "gemini", "content": "応答テキスト文字列", "thoughts": [...], ...}
  */
 
-import * as fs from "fs";
 import { RuleBasedEmotionClassifier } from "../services/ruleBasedEmotionClassifier";
 import type { SpeakMessage } from "../adapters/harnessAdapter";
 
@@ -28,11 +17,8 @@ interface GeminiMessage {
   id?: string;
   type: string;
   content?: string | Array<{ text?: string }>;
-}
-
-interface GeminiSessionFile {
-  sessionId?: string;
-  messages?: GeminiMessage[];
+  thoughts?: unknown[];
+  toolCalls?: unknown[];
 }
 
 /**
@@ -50,7 +36,7 @@ export function parseGeminiMessage(message: GeminiMessage): SpeakMessage[] {
     // type === "gemini" の場合、content は文字列
     text = content.trim();
   } else if (Array.isArray(content)) {
-    // 将来的な形式変更（JSONL移行後）に備えて配列にも対応
+    // 将来的な形式変更に備えて配列にも対応
     text = content
       .map((item) => item.text ?? "")
       .join("")
@@ -64,21 +50,17 @@ export function parseGeminiMessage(message: GeminiMessage): SpeakMessage[] {
 }
 
 /**
- * Gemini CLIのセッションJSONファイルを解析してセッションIDとメッセージを取得する
- * @param filePath - セッションJSONファイルのパス
- * @returns { sessionId, messages } またはパース失敗時は null
+ * Gemini CLIのJSONLログ行を解析してアシスタントメッセージを抽出する
+ * @param line - JSONLログファイルの1行
+ * @returns SpeakMessage의 配列
  */
-export function parseGeminiSessionFile(
-  filePath: string,
-): { sessionId: string | null; messages: GeminiMessage[] } | null {
+export function parseGeminiLogLine(line: string): SpeakMessage[] {
   try {
-    const raw = fs.readFileSync(filePath, "utf8");
-    const data: GeminiSessionFile = JSON.parse(raw);
-    return {
-      sessionId: data.sessionId ?? null,
-      messages: Array.isArray(data.messages) ? data.messages : [],
-    };
+    const data: GeminiMessage = JSON.parse(line);
+    // メタデータ行などは無視
+    if (!data.id || data.type !== "gemini") return [];
+    return parseGeminiMessage(data);
   } catch {
-    return null;
+    return [];
   }
 }


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- Gemini CLI v0.39からログ形式が JSON（全体書き換え）から JSONL（追記型）に変更されたため、アダプターとパーサーを対応させた
- `geminiCliAdapter.ts`: `JsonHarnessAdapter`（`mode: "json"`）から `HarnessAdapter`（JSONL差分読み取り）に変更
- `geminiCliParser.ts`: `parseGeminiSessionFile`（ファイル全体読み取り）を廃止し、`parseGeminiLogLine`（1行単位解析）に置き換え
- `harnessAdapter.ts`: `JsonlHarnessAdapter` / `JsonHarnessAdapter` の2インターフェースを統合し、`HarnessAdapter` 1つに簡略化
- `logMonitor.ts`: `mode` によるモード分岐ロジックを削除してシンプル化
- 監視対象ファイルの拡張子を `.json` → `.jsonl` に変更
- ストリーミング中の空コンテンツ行で同一IDを消費しないよう、ID重複排除ロジックを調整

## :camera: なぜやったのか（背景・目的）

Gemini CLI v0.39でログの書き込み形式が変更され、従来のJSON全体書き換え方式（`session-*.json`）からJSONL追記方式（`session-*.jsonl`）になった。これに伴い既存の実装ではGemini CLIの応答が検出されなくなったため対応が必要だった。また、今回の変更でGemini CLIもClaudeCode/Codexと同じJSONL処理パスに統一され、アダプターインターフェースの複雑さが解消された。

## :bookmark: 関連URL

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)