### PR TITLE
監視開始時にGemini CLIの処理済みIDを既存ログから復元する

### DIFF
--- a/electron/adapters/geminiCliAdapter.test.ts
+++ b/electron/adapters/geminiCliAdapter.test.ts
@@ -74,6 +74,43 @@ describe("createGeminiCliAdapter (JSONL)", () => {
     expect(second.map((m) => m.text)).toEqual(["本番の回答です。"]);
   });
 
+  it("既存ログから処理済みIDを復元する", () => {
+    const adapter = createGeminiCliAdapter();
+    const filePath = "/tmp/session.jsonl";
+    const initialLine = JSON.stringify({ id: "gemini-1", type: "gemini", content: "回答です。" });
+    const updatedLine = JSON.stringify({
+      id: "gemini-1",
+      type: "gemini",
+      content: "回答です。",
+      toolCalls: [{ name: "activate_skill", args: { name: "merge-pr" } }],
+    });
+
+    (fsMod.readFileSync as any).mockReturnValue(
+      [
+        JSON.stringify({ sessionId: "session-123" }),
+        JSON.stringify({ id: "user-1", type: "user", content: [{ text: "hi" }] }),
+        initialLine,
+      ].join("\n"),
+    );
+
+    adapter.initializeFile?.(filePath);
+
+    expect(adapter.parseLine(updatedLine, filePath)).toEqual([]);
+  });
+
+  it("既存ログ内の空メッセージではIDを消費しない", () => {
+    const adapter = createGeminiCliAdapter();
+    const filePath = "/tmp/session.jsonl";
+    const lineEmpty = JSON.stringify({ id: "gemini-1", type: "gemini", content: "", thoughts: [{}] });
+    const lineFull = JSON.stringify({ id: "gemini-1", type: "gemini", content: "本番の回答です。" });
+
+    (fsMod.readFileSync as any).mockReturnValue(lineEmpty);
+
+    adapter.initializeFile?.(filePath);
+
+    expect(adapter.parseLine(lineFull, filePath).map((m) => m.text)).toEqual(["本番の回答です。"]);
+  });
+
   it("セッションIDでフィルタ判定する", () => {
     const adapter = createGeminiCliAdapter();
     const filePath = "/tmp/session.jsonl";

--- a/electron/adapters/geminiCliAdapter.ts
+++ b/electron/adapters/geminiCliAdapter.ts
@@ -30,6 +30,26 @@ export function createGeminiCliAdapter(): HarnessAdapter {
   // ファイルパス → 処理済みメッセージIDのセット（追記型でも更新があるためIDで重複排除が必要）
   const processedIds = new Map<string, Set<string>>();
 
+  function getProcessedIds(filePath: string): Set<string> {
+    let ids = processedIds.get(filePath);
+    if (!ids) {
+      ids = new Set();
+      processedIds.set(filePath, ids);
+    }
+    return ids;
+  }
+
+  function markProcessedId(line: string, filePath: string): void {
+    try {
+      const data = JSON.parse(line);
+      if (!data.id) return;
+      if (parseGeminiLogLine(line).length === 0) return;
+      getProcessedIds(filePath).add(data.id);
+    } catch {
+      // ignore
+    }
+  }
+
   return {
     getWatchPaths() {
       return [geminiTmpDir];
@@ -48,22 +68,32 @@ export function createGeminiCliAdapter(): HarnessAdapter {
       };
     },
 
+    initializeFile(filePath: string): void {
+      try {
+        const content = fs.readFileSync(filePath, "utf8");
+        for (const line of content.split("\n")) {
+          if (!line.trim()) continue;
+          markProcessedId(line, filePath);
+        }
+      } catch {
+        // ignore
+      }
+    },
+
     parseLine(line: string, logFilePath?: string): SpeakMessage[] {
       try {
         const data = JSON.parse(line);
         const id = data.id;
+        const processedForFile = logFilePath ? getProcessedIds(logFilePath) : undefined;
 
         // メッセージではない行（メタデータなど）や、既に処理済みのIDはスキップ
-        if (!id || (logFilePath && processedIds.get(logFilePath)?.has(id))) {
+        if (!id || processedForFile?.has(id)) {
           return [];
         }
 
         const parsed = parseGeminiLogLine(line);
-        if (parsed.length > 0 && logFilePath) {
-          if (!processedIds.has(logFilePath)) {
-            processedIds.set(logFilePath, new Set());
-          }
-          processedIds.get(logFilePath)!.add(id);
+        if (parsed.length > 0 && processedForFile) {
+          processedForFile.add(id);
         }
 
         return parsed;

--- a/electron/adapters/harnessAdapter.ts
+++ b/electron/adapters/harnessAdapter.ts
@@ -37,6 +37,12 @@ export interface HarnessAdapter {
   parseLine(line: string, logFilePath?: string): SpeakMessage[];
 
   /**
+   * 監視開始時に既存ファイルからアダプター固有の状態を復元する
+   * @param filePath - 初期化対象のログファイルパス
+   */
+  initializeFile?(filePath: string): void;
+
+  /**
    * セッションIDに基づいてファイルを処理すべきか判定する
    * @param filePath - 判定対象のファイルパス
    * @param activeSessionId - 現在アクティブなセッションID

--- a/electron/logMonitor.ts
+++ b/electron/logMonitor.ts
@@ -113,6 +113,7 @@ export function createLogMonitor(
   watcher.on("add", (filePath: string) => {
     // ファイル位置を現在の末尾に初期化（既存ログの再生を防ぐ）
     initializeFilePosition(filePath);
+    adapter.initializeFile?.(filePath);
   });
 
   watcher.on("change", (filePath: string) => {


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- `HarnessAdapter` インターフェースにオプショナルメソッド `initializeFile?` を追加
- `GeminiCliAdapter` に `initializeFile` を実装し、監視開始時に既存ファイルの内容を読み込んで処理済みメッセージIDを復元するようにした
- `logMonitor.ts` の `watcher.on("add")` ハンドラーで `adapter.initializeFile?.()` を呼び出すよう対応
- 上記変更に対応するテストを追加

## :camera: なぜやったのか（背景・目的）

アプリ起動時にすでに存在するGemini CLIのログファイルを監視し始める際、ファイルの末尾位置は初期化していたが、処理済みメッセージIDのセットは初期化されていなかった。

そのため、Gemini CLIが同一IDのメッセージを追記更新した場合（例: `thoughts` のみの空メッセージが後から内容付きのメッセージに更新される場合）、アプリ再起動後に既存ログの内容を再発話してしまう問題があった。

`initializeFile` で既存ログから処理済みIDを先読みすることで、再起動後の重複発話を防ぐ。

## :bookmark: 関連URL

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)