### PR TITLE
Gemini既存ログ復元時の不要な感情判定を防止

### DIFF
--- a/electron/adapters/geminiCliAdapter.test.ts
+++ b/electron/adapters/geminiCliAdapter.test.ts
@@ -10,6 +10,7 @@ import { createGeminiCliAdapter } from "./geminiCliAdapter";
 
 describe("createGeminiCliAdapter (JSONL)", () => {
   const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -21,6 +22,8 @@ describe("createGeminiCliAdapter (JSONL)", () => {
     } else {
       process.env.GEMINI_CLI_HOME = originalGeminiCliHome;
     }
+
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   it("GEMINI_CLI_HOME配下の.gemini/tmpを監視する", () => {
@@ -96,6 +99,27 @@ describe("createGeminiCliAdapter (JSONL)", () => {
     adapter.initializeFile?.(filePath);
 
     expect(adapter.parseLine(updatedLine, filePath)).toEqual([]);
+  });
+
+  it("既存ログのID復元時は感情判定を実行しない", () => {
+    process.env.NODE_ENV = "development";
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const adapter = createGeminiCliAdapter();
+    const filePath = "/tmp/session.jsonl";
+
+    (fsMod.readFileSync as any).mockReturnValue(
+      [
+        JSON.stringify({ sessionId: "session-123" }),
+        JSON.stringify({ id: "gemini-1", type: "gemini", content: "嬉しいです！" }),
+      ].join("\n"),
+    );
+
+    adapter.initializeFile?.(filePath);
+
+    expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining("[EmotionClassifier]"));
+    expect(
+      adapter.parseLine(JSON.stringify({ id: "gemini-1", type: "gemini", content: "嬉しいです！" }), filePath),
+    ).toEqual([]);
   });
 
   it("既存ログ内の空メッセージではIDを消費しない", () => {

--- a/electron/adapters/geminiCliAdapter.ts
+++ b/electron/adapters/geminiCliAdapter.ts
@@ -39,11 +39,30 @@ export function createGeminiCliAdapter(): HarnessAdapter {
     return ids;
   }
 
+  function hasSpeakableGeminiContent(data: { type?: string; content?: unknown }): boolean {
+    if (data.type !== "gemini") return false;
+
+    const content = data.content;
+    if (typeof content === "string") {
+      return content.trim().length > 0;
+    }
+
+    if (Array.isArray(content)) {
+      return content.some((item) => {
+        if (!item || typeof item !== "object") return false;
+        const text = (item as { text?: unknown }).text;
+        return typeof text === "string" && text.trim().length > 0;
+      });
+    }
+
+    return false;
+  }
+
   function markProcessedId(line: string, filePath: string): void {
     try {
       const data = JSON.parse(line);
       if (!data.id) return;
-      if (parseGeminiLogLine(line).length === 0) return;
+      if (!hasSpeakableGeminiContent(data)) return;
       getProcessedIds(filePath).add(data.id);
     } catch {
       // ignore


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- Gemini CLIアダプターの既存ログID復元処理で、通常パーサーを呼ばずに読み上げ対象かを軽量判定するように変更
- 起動時の既存Geminiログ復元でEmotionClassifierが実行されないことをテストで確認

## :camera: なぜやったのか（背景・目的）

アプリ起動時に過去のGemini CLIログを処理済みIDとして復元する際、発話に使わないにもかかわらず通常パーサー経由で感情判定が走っていたため。開発モードでは過去ログ分のEmotionClassifierログが流れ、不要な処理にもなっていたため、ID復元に必要な判定だけを行うようにした。

## :bookmark: 関連URL


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)