### PR TITLE
vitest.setup.tsのglobal参照をglobalThisに修正

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,5 +25,5 @@
     "types": ["vite/client"],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["vitest.setup.ts", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -31,11 +31,11 @@ class LocalStorageMock {
   }
 }
 
-global.localStorage = new LocalStorageMock() as Storage;
+globalThis.localStorage = new LocalStorageMock() as Storage;
 
 // 各テスト前にlocalStorageをクリア
 beforeEach(() => {
-  global.localStorage.clear();
+  globalThis.localStorage.clear();
 });
 
 afterEach(() => {


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- `vitest.setup.ts` の `global.localStorage` を `globalThis.localStorage` に変更
- `tsconfig.app.json` の `include` に `vitest.setup.ts` を追加

## :camera: なぜやったのか（背景・目的）

`vitest.setup.ts` が `global` (Node.js固有のグローバル) を参照していたため、jsdom環境向けの `tsconfig.app.json`（DOM libを持つが Node types を含まない）でVSCode上に型エラーが発生していた。
`globalThis` はES2020+の標準仕様でNode.js・ブラウザ両環境に対応しており、どのTypeScript lib設定でも型が解決される。また、`vitest.setup.ts` をどのtsconfigの `include` にも追加していなかったため、VSCodeが参照するtsconfigが不定だったのを `tsconfig.app.json` に明示した。

## :bookmark: 関連URL

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)