### PR TITLE
.claude/worktrees/をgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ public/licenses.json
 
 # Claude
 .claude/plans
+.claude/worktrees/


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

`.gitignore` に `.claude/worktrees/` を追加した。

## :camera: なぜやったのか（背景・目的）

Claude Code のワークツリー機能が作成するディレクトリ（`.claude/worktrees/`）をgitの追跡対象から除外するため。

## :bookmark: 関連URL

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)