### PR TITLE
Codex用MCP設定を追加

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+[mcp_servers.electron]
+args = ["-y", "electron-mcp-server"]
+command = "npx"
+
+[mcp_servers.electron.env]
+SCREENSHOT_ENCRYPTION_KEY = "e1414e178896247edce2eac531330081a4273b1809750a39712365f47e9f6974"
+SECURITY_LEVEL = "development"


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- .codex/config.toml を追加し、Codex から electron-mcp-server を利用できるように設定した
- electron-mcp-server の実行コマンド、スクリーンショット暗号化キー、development セキュリティレベルを定義した

## :camera: なぜやったのか（背景・目的）

- Codex 環境からElectronアプリのウィンドウ情報取得やスクリーンショット撮影を安定して実行できるようにするため
- ローカルのMCPサーバー設定をリポジトリ配下に配置し、開発時の確認手順を使いやすくするため

## :bookmark: 関連URL


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)