### PR TITLE
設定画面のヘッダーに「バージョン情報」と「終了」のボタンを追加

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -107,6 +107,27 @@ const getTrayIconPath = (): string => {
   return path.join(iconsDir, ext);
 };
 
+const showAboutDialog = async () => {
+  const { response } = await dialog.showMessageBox(mainWindow!, {
+    type: "info",
+    title: "CC Mascot",
+    message: `CC Mascot v${app.getVersion()}`,
+    detail: [
+      `Electron: v${process.versions.electron}`,
+      `Chrome: v${process.versions.chrome}`,
+      `Node.js: v${process.versions.node}`,
+    ].join("\n"),
+    buttons: ["閉じる", "アップデートを確認", "Webサイト", "ライセンス情報"],
+  });
+  if (response === 1) {
+    checkForUpdatesManually();
+  } else if (response === 2) {
+    shell.openExternal("https://kazakago.github.io/cc-mascot/");
+  } else if (response === 3) {
+    createLicenseWindow();
+  }
+};
+
 // Update tray context menu (called when visibility state changes)
 const updateTrayMenu = () => {
   if (!tray) return;
@@ -134,24 +155,7 @@ const updateTrayMenu = () => {
     {
       label: "バージョン情報",
       click: async () => {
-        const { response } = await dialog.showMessageBox(mainWindow!, {
-          type: "info",
-          title: "CC Mascot",
-          message: `CC Mascot v${app.getVersion()}`,
-          detail: [
-            `Electron: v${process.versions.electron}`,
-            `Chrome: v${process.versions.chrome}`,
-            `Node.js: v${process.versions.node}`,
-          ].join("\n"),
-          buttons: ["閉じる", "アップデートを確認", "Webサイト", "ライセンス情報"],
-        });
-        if (response === 1) {
-          checkForUpdatesManually();
-        } else if (response === 2) {
-          shell.openExternal("https://kazakago.github.io/cc-mascot/");
-        } else if (response === 3) {
-          createLicenseWindow();
-        }
+        await showAboutDialog();
       },
     },
     {
@@ -890,6 +894,14 @@ ipcMain.handle("get-auto-update-check", () => {
 ipcMain.handle("set-auto-update-check", (_event, value: boolean) => {
   store.set("autoUpdateCheck", value);
   return true;
+});
+
+ipcMain.handle("show-about", async () => {
+  await showAboutDialog();
+});
+
+ipcMain.handle("quit-app", () => {
+  app.quit();
 });
 
 const ANIMATION_CATEGORIES = ["idle", "happy", "angry", "sad", "relaxed", "surprised"] as const;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -155,4 +155,10 @@ contextBridge.exposeInMainWorld("electron", {
       ipcRenderer.removeListener("active-session-changed", listener);
     };
   },
+  showAboutDialog: (): Promise<void> => {
+    return ipcRenderer.invoke("show-about");
+  },
+  quitApp: (): Promise<void> => {
+    return ipcRenderer.invoke("quit-app");
+  },
 });

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -333,6 +333,22 @@ export default function SettingsPanel({
               </svg>
             </button>
           </div>
+          <div className="flex items-center gap-2 mt-3">
+            <button
+              type="button"
+              onClick={() => window.electron?.showAboutDialog?.()}
+              className="flex-1 py-1.5 rounded-lg text-xs font-medium bg-slate-100 hover:bg-slate-200 text-slate-700 transition-colors cursor-pointer border border-slate-200/50 text-center"
+            >
+              バージョン情報
+            </button>
+            <button
+              type="button"
+              onClick={() => window.electron?.quitApp?.()}
+              className="flex-1 py-1.5 rounded-lg text-xs font-medium bg-red-50 hover:bg-red-100 text-red-600 border border-red-200 transition-colors cursor-pointer text-center"
+            >
+              終了
+            </button>
+          </div>
         </div>
 
         <div className="p-6 space-y-5">

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -49,6 +49,8 @@ declare global {
       getActiveSession: () => Promise<string | null>;
       clearActiveSession: () => Promise<boolean>;
       onActiveSessionChanged: (callback: (sessionId: string | null) => void) => () => void;
+      showAboutDialog: () => Promise<void>;
+      quitApp: () => Promise<void>;
     };
   }
 }


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- メインプロセス（`electron/main.ts`）に、バージョン情報ダイアログの表示とアプリの終了を行うIPCハンドラー（`show-about` / `quit-app`）を追加しました。
- プリロードスクリプト（`electron/preload.ts`）および型定義（`src/global.d.ts`）に、上記IPC機能を呼び出すためのメソッド（`showAboutDialog` / `quitApp`）を定義しました。
- 設定画面（`src/components/SettingsPanel.tsx`）のヘッダー部分を2段構成のレイアウトに変更し、2段目に「バージョン情報」ボタンと「終了」ボタンを追加しました。

## :camera: なぜやったのか（背景・目的）

- 設定画面からもメニューバーやシステムトレイと同じ「バージョン情報」の確認と「アプリの終了」が行えるようにするため。

## :bookmark: 関連URL

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
