### PR TITLE
Renovateの設定ファイルを追加しGitHub Actionsのハッシュピン留めを有効化

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended", "helpers:pinGitHubActionDigests"],
+}


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）

- Renovateの設定ファイル `.github/renovate.json5` を新規追加しました。
- `helpers:pinGitHubActionDigests` プリセットを有効化し、GitHub Actionsの依存関係のハッシュピン留めをRenovateで自動更新・管理できるよう設定しました。

## :camera: なぜやったのか（背景・目的）

- GitHub Actionsを安全に利用するため、パッケージやアクションのバージョン指定をSHAハッシュ値で固定することが推奨されるため、その自動更新プロセスをRenovateによって自動化・保守しやすくするためです。

## :bookmark: 関連URL


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
