### PR TITLE
RenovateのlockFileMaintenanceを有効化

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended", "helpers:pinGitHubActionDigests"],
+  lockFileMaintenance: {
+    enabled: true,
+  },
 }


### PR DESCRIPTION
## :memo: なにをやったか（変更の概要）
- `.github/renovate.json5` に `lockFileMaintenance` の設定を追加し、有効化しました。

## :camera: なぜやったのか（背景・目的）
- 依存関係のアップデートにおいて、直接 `package.json` の変更を伴わない（指定範囲内での）ロックファイル（`package-lock.json`）の更新PRが大量に作成されるのを防ぐため。
- ロックファイルの更新を週に1回（デフォルトの月曜早朝）に一括してまとめることで、PRのノイズを減らし管理を容易にします。

## :bookmark: 関連URL

---
🤖 Generated with [Antigravity](https://gemini.google.com/)
